### PR TITLE
[Curves] Fix zNear to make depth testing effective

### DIFF
--- a/src/bundles/curves/curves_webgl.ts
+++ b/src/bundles/curves/curves_webgl.ts
@@ -128,7 +128,7 @@ function drawCurve(
 
     const fieldOfView = (45 * Math.PI) / 180;
     const aspect = gl.canvas.width / gl.canvas.height;
-    const zNear = 0.01; // Must not be zero, depth testing losees precision proportional to log(zFar / zNear)
+    const zNear = 0.01; // Must not be zero, depth testing loses precision proportional to log(zFar / zNear)
     const zFar = 50.0;
     mat4.perspective(projMat, fieldOfView, aspect, zNear, zFar);
   }

--- a/src/bundles/curves/curves_webgl.ts
+++ b/src/bundles/curves/curves_webgl.ts
@@ -128,7 +128,7 @@ function drawCurve(
 
     const fieldOfView = (45 * Math.PI) / 180;
     const aspect = gl.canvas.width / gl.canvas.height;
-    const zNear = 0;
+    const zNear = 0.01; // Must not be zero, depth testing losees precision proportional to log(zFar / zNear)
     const zFar = 50.0;
     mat4.perspective(projMat, fieldOfView, aspect, zNear, zFar);
   }


### PR DESCRIPTION
# Description

Refer to the following code in `curves_webgl.ts`:
```
gl.enable(gl.DEPTH_TEST); // Enable depth testing
gl.depthFunc(gl.LEQUAL); // Near things obscure far things
```
However this does not seem to work in rendering 3D curves as shown below:

1. Part of the curves that are rendered later will always replace those rendered earlier
2. As the box is rendered earlier, it is always behind the curves.

![68747470733a2f2f692e696d6775722e636f6d2f654331595a44302e676966](https://user-images.githubusercontent.com/75558451/115117743-ac717f80-9fd2-11eb-85cf-6c319a918368.gif)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run the following code to test whether near things obscure far things. The above mentioned issues should have been fixed.
```
import {
    make_3D_color_point,
    draw_3D_connected_full_view_proportional,
    draw_3D_points_full_view_proportional
} from "curves";

const to_domain = x => (2 * x - 1) * 100 * math_PI;

const heart_scale = (t, heart) => math_sin(math_PI * t) * heart;

const colored_heart = t =>  make_3D_color_point(
    t < 0.5 ?30*math_pow(t, 2) : 30*(2*math_pow(0.5, 2)-math_pow(1 - t, 2)),
    heart_scale(t, 16 * math_pow(math_sin(to_domain(t)), 3)),
    heart_scale(t, 13 * math_cos(to_domain(t)) - 5 * math_cos(2 * to_domain(t)) 
    - 2 * math_cos(3 * to_domain(t)) - math_cos(4 * to_domain(t))),
    math_pow(math_cos(2 * math_PI * t), 2) * 255,   // r-component
    math_pow(math_sin(2 * math_PI * t), 2) * 255,   // g-component
    t * 255);                                       // b-component

draw_3D_points_full_view_proportional(60000)(colored_heart);
```
![ezgif com-gif-maker](https://user-images.githubusercontent.com/75558451/115116991-0d975400-9fcf-11eb-8099-ddc56833ef44.gif)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
