### PR TITLE
change toreplstring of rendered rune to <RENDERING>

### DIFF
--- a/src/bundles/rune/functions.ts
+++ b/src/bundles/rune/functions.ts
@@ -564,6 +564,7 @@ export function show(rune: Rune): Rune {
   throwIfNotRune('show', rune);
   const normalRune = copyRune(rune);
   normalRune.drawMethod = 'normal';
+  normalRune.toReplString = () => '<RENDERING>';
   return normalRune;
 }
 
@@ -577,6 +578,7 @@ export function anaglyph(rune: Rune): Rune {
   throwIfNotRune('anaglyph', rune);
   const analyphRune = copyRune(rune);
   analyphRune.drawMethod = 'anaglyph';
+  analyphRune.toReplString = () => '<RENDERING>';
   return analyphRune;
 }
 
@@ -591,6 +593,7 @@ export function hollusion_magnitude(rune: Rune, magnitude: number = 0.1): Rune {
   const hollusionRune = copyRune(rune);
   hollusionRune.drawMethod = 'hollusion';
   hollusionRune.hollusionDistance = magnitude;
+  hollusionRune.toReplString = () => '<RENDERING>';
   return hollusionRune;
 }
 

--- a/src/bundles/rune/ruomu_journal.md
+++ b/src/bundles/rune/ruomu_journal.md
@@ -31,3 +31,6 @@
 
 ### 5 Aug 2021
 - 14:30pm - 15:10pm : fix bugs
+
+### 
+- 12:30pm - 1:00pm : working on #88

--- a/src/tabs/Rune/index.tsx
+++ b/src/tabs/Rune/index.tsx
@@ -99,7 +99,9 @@ export default {
   toSpawn: (context: any) => {
     function isValidFunction(value: any): value is Rune {
       try {
-        return value.toReplString() === '<RUNE>' && value.drawMethod !== '';
+        return (
+          value.toReplString() === '<RENDERING>' && value.drawMethod !== ''
+        );
       } catch (e) {
         return false;
       }


### PR DESCRIPTION
## BUG fix
In REPL, show \<RENDERING\> instead of \<RUNE\> for the result of ```show(), anaglyph(), hollusion(), hollusion_magnitude()```.
Refer to #88 