### PR TITLE
renaming runes to rune in documentation

### DIFF
--- a/src/bundles/rune/functions.ts
+++ b/src/bundles/rune/functions.ts
@@ -1,8 +1,8 @@
 /**
- * RUNES provide functions for drawing runes.
+ * The module `rune` provides functions for drawing runes.
  *
  * A *Rune* is defined by its vertices (x,y,z,t), the colors on its vertices (r,g,b,a), a transformation matrix for rendering the Rune and a (could be empty) list of its sub-Runes.
- * @module runes
+ * @module rune
  */
 import { mat4, vec3 } from 'gl-matrix';
 import { Rune } from './types';


### PR DESCRIPTION
documentation incorrectly mentioned "runes" instead of "rune"
