### PR TITLE
[rune] (please merge after rune contest) fix `overlay_frac()` with input 0, and `rotate()` documentation. 

### DIFF
--- a/src/bundles/rune/functions.ts
+++ b/src/bundles/rune/functions.ts
@@ -159,7 +159,7 @@ export function translate(x: number, y: number, rune: Rune): Rune {
  * given in radians, in anti-clockwise direction.
  * Note that parts of the Rune
  * may be cropped as a result.
- * @param {number} rad - fraction between 0 and 1
+ * @param {number} rad - angle in radians
  * @param {Rune} rune - given Rune
  * @return {Rune} rotated Rune
  */

--- a/src/bundles/rune/ruomu_journal.md
+++ b/src/bundles/rune/ruomu_journal.md
@@ -47,3 +47,6 @@
 
 ### 21 Aug 2021
 - 18:00pm - 21:00pm : fix the memory leak / high memomry consumption by hollusion #95
+
+### 5 Sep 2021
+- 12:30 - 13:30 : fix #97 #100


### PR DESCRIPTION
# Description
**Please only merge this PR after the rune contest voting**
- `overlay_frac()` now clips the input fraction from [0,1] to [1E-6, 1 - 1E-6]. As a result, when the input fraction is 0 or 1, there will not be two runes sharing the same plane. This avoids graphical glitches when the input is 0/1.
- `rotate()` now is correctly documented.

Fix #97 #100 


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
`show(overlay_frac(0, red(heart), sail));`
now correctly shows a red heart on a black sail.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
