### PR TITLE
Fix erroneous handling of 0 duration sound played

### DIFF
--- a/src/bundles/sound/functions.ts
+++ b/src/bundles/sound/functions.ts
@@ -315,7 +315,7 @@ export function play(sound: Sound): AudioPlayed {
     // If a sound is already playing, terminate execution.
   } else if (isPlaying) {
     throw new Error('play: audio system still playing previous sound');
-  } else if (get_duration(sound) <= 0) {
+  } else if (get_duration(sound) < 0) {
     throw new Error('play: duration of sound is negative');
   } else {
     // Instantiate audio context if it has not been instantiated.


### PR DESCRIPTION
# Description

Fixes #104 , which was a specific case of playing a sound of zero duration.

## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

import { play, consecutively, make_sound } from "sound";

// play(make_sound(t => 0, 0));
// play(consecutively(null));

These will now no longer throw errors.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
