### PR TITLE
Fix install filter bug

### DIFF
--- a/src/bundles/pix_n_flix/functions.ts
+++ b/src/bundles/pix_n_flix/functions.ts
@@ -65,9 +65,13 @@ let startTime: number;
 
 /** @hidden */
 function setupData(): void {
-  for (let i = 0; i < WIDTH; i += 1) {
+  for (let i = 0; i < HEIGHT; i += 1) {
     pixels[i] = [];
     temporaryPixels[i] = [];
+    for (let j = 0; j < WIDTH; j += 1) {
+      pixels[i][j] = [0, 0, 0, 255];
+      temporaryPixels[i][j] = [0, 0, 0, 255];
+    }
   }
 }
 
@@ -142,7 +146,7 @@ function drawFrame(): void {
   try {
     filter(pixels, temporaryPixels);
     writeToBuffer(pixelObj.data, temporaryPixels);
-  } catch (e) {
+  } catch (e: any) {
     // eslint-disable-next-line no-console
     console.error(JSON.stringify(e));
     const errMsg = `There is an error with filter function, filter will be reset to default. ${e.name}: ${e.message}`;


### PR DESCRIPTION
# Description
Changes:
* Fixes bug when install filter is ran
![image](https://user-images.githubusercontent.com/50147457/136934041-f278182e-043c-4839-b9bb-d55a610413c3.png)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Testing all of the imported functions:
![image](https://user-images.githubusercontent.com/50147457/136935380-4220c2cd-16ee-4d36-9cc2-4eca55bbd2c7.png)

```
import { 
  start,
  red_of,
  blue_of,
  green_of,
  alpha_of,
  set_rgba,
  video_height,
  video_width,
  copy_image,
  install_filter,
  reset_filter,
  compose_filter, 
  set_dimensions,
  set_fps 
    
} from "pix_n_flix";

set_dimensions(300,300);
set_fps(8);

function my_first_filter(ignore, dest) {
    const WIDTH = video_width();
    const HEIGHT = video_height();
    
    for (let i = 0; i < HEIGHT; i = i + 1) {
        for (let j = 0; j < WIDTH; j = j + 1) {
            dest[i][j][0] = 255;
            dest[i][j][1] = green_of(ignore[i][j]);
            dest[i][j][2] = blue_of(ignore[i][j]);
            dest[i][j][3] = alpha_of(ignore[i][j]);
        }
    }
}

function my_second_filter(ignore, dest) {
    const WIDTH = video_width();
    const HEIGHT = video_height();
    
    for (let i = 0; i < HEIGHT; i = i + 1) {
        for (let j = 0; j < WIDTH; j = j + 1) {
            set_rgba(dest[i][j],
                red_of(ignore[i][j]),
                green_of(ignore[i][j]),
                255,
                alpha_of(ignore[i][j]));
        }
    }
}
// combines red and blue filter to form a purple filter
install_filter(compose_filter(my_first_filter, my_second_filter));

// uncomment this to see reset filter in action
// reset_filter();

start();
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
