### PR TITLE
Disable height and width buttons for pix_n_flix

### DIFF
--- a/src/tabs/Pixnflix/index.tsx
+++ b/src/tabs/Pixnflix/index.tsx
@@ -221,6 +221,7 @@ class PixNFlix extends React.Component<Props, State> {
             <div className='sa-video-header-numeric-input'>
               {/* <Tooltip2 content='Change width'> */}
               <NumericInput
+                disabled
                 leftIcon={IconNames.HORIZONTAL_DISTRIBUTION}
                 style={{ width: 70 }}
                 value={width}
@@ -236,6 +237,7 @@ class PixNFlix extends React.Component<Props, State> {
             <div className='sa-video-header-numeric-input'>
               {/* <Tooltip2 content='Change height'> */}
               <NumericInput
+                disabled
                 leftIcon={IconNames.VERTICAL_DISTRIBUTION}
                 style={{ width: 70 }}
                 value={height}


### PR DESCRIPTION
# Description
* Disable height and width buttons for pix_n_flix tab
![image](https://user-images.githubusercontent.com/50147457/137117848-d5f7541e-221c-425b-89a8-16648f11b09e.png)

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
