### PR TITLE
Stanley/pix nflix bugfix

### DIFF
--- a/src/bundles/pix_n_flix/functions.ts
+++ b/src/bundles/pix_n_flix/functions.ts
@@ -58,6 +58,16 @@ let videoIsPlaying: boolean = false;
 let FPS: number = DEFAULT_FPS;
 let requestId: number;
 let startTime: number;
+let numberOfFrames: number = 0;
+
+// Water Leakage Experiments
+let renderCount: number = 0;
+const randID: number = Math.floor(Math.random() * 1000);
+function incrementRenderCount() {
+  renderCount += 1;
+  // eslint-disable-next-line no-console
+  console.log(randID, renderCount);
+}
 
 // =============================================================================
 // Module's Private Functions
@@ -182,6 +192,19 @@ function draw(timestamp: number): void {
   if (elapsed > 1000 / FPS) {
     drawFrame();
     startTime = timestamp;
+
+    if (numberOfFrames > 0) {
+      if (numberOfFrames === 1) {
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        stopVideo();
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        // deinit();
+        // eslint-disable-next-line no-console
+        console.log('Disabling video');
+      }
+      numberOfFrames -= 1;
+    }
+    incrementRenderCount();
   }
 }
 
@@ -325,6 +348,8 @@ function init(
   canvas: CanvasElement,
   _errorLogger: ErrorLogger
 ): number[] {
+  // eslint-disable-next-line no-console
+  console.log('Initialising', randID);
   videoElement = video;
   canvasElement = canvas;
   errorLogger = _errorLogger;
@@ -344,10 +369,14 @@ function init(
  * @hidden
  */
 function deinit(): void {
+  stopVideo();
   const stream = videoElement.srcObject;
   if (!stream) {
     return;
   }
+  // eslint-disable-next-line no-console
+  console.log('Deinitializing', randID);
+
   stream.getTracks().forEach((track) => {
     track.stop();
   });
@@ -547,4 +576,14 @@ export function set_dimensions(width: number, height: number): void {
  */
 export function set_fps(fps: number): void {
   enqueue(() => updateFPS(fps));
+}
+
+/**
+ * Sets number of frames to display before cutting the video.
+ * Note: Any value <= 0 will be taken to be indefinite number of frames (Default)
+ *
+ * @param nframes Number of frames to display before the video stream cuts.
+ */
+export function cut_at(nframes: number): void {
+  numberOfFrames = nframes;
 }

--- a/src/bundles/pix_n_flix/functions.ts
+++ b/src/bundles/pix_n_flix/functions.ts
@@ -60,15 +60,6 @@ let requestId: number;
 let startTime: number;
 let numberOfFrames: number = 0;
 
-// Water Leakage Experiments
-let renderCount: number = 0;
-const randID: number = Math.floor(Math.random() * 1000);
-function incrementRenderCount() {
-  renderCount += 1;
-  // eslint-disable-next-line no-console
-  console.log(randID, renderCount);
-}
-
 // =============================================================================
 // Module's Private Functions
 // =============================================================================
@@ -197,14 +188,9 @@ function draw(timestamp: number): void {
       if (numberOfFrames === 1) {
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         stopVideo();
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        // deinit();
-        // eslint-disable-next-line no-console
-        console.log('Disabling video');
       }
       numberOfFrames -= 1;
     }
-    incrementRenderCount();
   }
 }
 
@@ -348,8 +334,6 @@ function init(
   canvas: CanvasElement,
   _errorLogger: ErrorLogger
 ): number[] {
-  // eslint-disable-next-line no-console
-  console.log('Initialising', randID);
   videoElement = video;
   canvasElement = canvas;
   errorLogger = _errorLogger;
@@ -374,9 +358,6 @@ function deinit(): void {
   if (!stream) {
     return;
   }
-  // eslint-disable-next-line no-console
-  console.log('Deinitializing', randID);
-
   stream.getTracks().forEach((track) => {
     track.stop();
   });
@@ -579,11 +560,11 @@ export function set_fps(fps: number): void {
 }
 
 /**
- * Sets number of frames to display before cutting the video.
+ * Sets number of frames to display before pausing the video.
  * Note: Any value <= 0 will be taken to be indefinite number of frames (Default)
  *
- * @param nframes Number of frames to display before the video stream cuts.
+ * @param nframes Integer number of frames to display before the video is paused.
  */
-export function cut_at(nframes: number): void {
+export function pause_at(nframes: number): void {
   numberOfFrames = nframes;
 }

--- a/src/bundles/pix_n_flix/index.ts
+++ b/src/bundles/pix_n_flix/index.ts
@@ -14,6 +14,7 @@ import {
   snapshot,
   set_dimensions,
   set_fps,
+  pause_at,
 } from './functions';
 
 /**
@@ -38,4 +39,5 @@ export default () => ({
   snapshot,
   set_dimensions,
   set_fps,
+  pause_at,
 });

--- a/src/bundles/pix_n_flix/index.ts
+++ b/src/bundles/pix_n_flix/index.ts
@@ -14,7 +14,7 @@ import {
   snapshot,
   set_dimensions,
   set_fps,
-  pause_at,
+  stop_video_after,
 } from './functions';
 
 /**
@@ -39,5 +39,5 @@ export default () => ({
   snapshot,
   set_dimensions,
   set_fps,
-  pause_at,
+  stop_video_after,
 });


### PR DESCRIPTION
# Description

Added new stop_video_after function for pix-n-flix which ends the video and turns off the camera after a certain delay
Fixed the issue of growing lag over multiple runs by preventing multiple filters from running at once

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Added console.log calls to track the number of init(), deinit() and draw() calls during runtime. In the previous version, there were multiple draw calls per frame after multiple runs without refreshing the browser. With the updates made, such behaviour is no longer observed and the browser remains responsive after several runs.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
