### PR TITLE
Stanley/pix nflix bugfix

### DIFF
--- a/src/bundles/pix_n_flix/functions.ts
+++ b/src/bundles/pix_n_flix/functions.ts
@@ -58,6 +58,16 @@ let videoIsPlaying: boolean = false;
 let FPS: number = DEFAULT_FPS;
 let requestId: number;
 let startTime: number;
+let numberOfFrames: number = 0;
+
+// Water Leakage Experiments
+let renderCount: number = 0;
+const randID: number = Math.floor(Math.random() * 1000);
+function incrementRenderCount() {
+  renderCount += 1;
+  // eslint-disable-next-line no-console
+  console.log(randID, renderCount);
+}
 
 // =============================================================================
 // Module's Private Functions
@@ -182,6 +192,19 @@ function draw(timestamp: number): void {
   if (elapsed > 1000 / FPS) {
     drawFrame();
     startTime = timestamp;
+
+    if (numberOfFrames > 0) {
+      if (numberOfFrames === 1) {
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        stopVideo();
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        // deinit();
+        // eslint-disable-next-line no-console
+        console.log('Disabling video');
+      }
+      numberOfFrames -= 1;
+    }
+    incrementRenderCount();
   }
 }
 
@@ -325,6 +348,8 @@ function init(
   canvas: CanvasElement,
   _errorLogger: ErrorLogger
 ): number[] {
+  // eslint-disable-next-line no-console
+  console.log('Initialising', randID);
   videoElement = video;
   canvasElement = canvas;
   errorLogger = _errorLogger;
@@ -344,10 +369,14 @@ function init(
  * @hidden
  */
 function deinit(): void {
+  stopVideo();
   const stream = videoElement.srcObject;
   if (!stream) {
     return;
   }
+  // eslint-disable-next-line no-console
+  console.log('Deinitializing', randID);
+
   stream.getTracks().forEach((track) => {
     track.stop();
   });
@@ -547,4 +576,14 @@ export function set_dimensions(width: number, height: number): void {
  */
 export function set_fps(fps: number): void {
   enqueue(() => updateFPS(fps));
+}
+
+/**
+ * Sets number of frames to display before cutting the video.
+ * Note: Any value <= 0 will be taken to be indefinite number of frames (Default)
+ *
+ * @param nframes Number of frames to display before the video stream cuts.
+ */
+export function cut_at(nframes: number): void {
+  numberOfFrames = nframes;
 }

--- a/src/bundles/pix_n_flix/functions.ts
+++ b/src/bundles/pix_n_flix/functions.ts
@@ -188,7 +188,7 @@ function draw(timestamp: number): void {
 
 /** @hidden */
 function startVideo(): void {
-  if (videoIsLoaded && videoIsPlaying) return;
+  if (!videoIsLoaded || videoIsPlaying) return;
   videoIsPlaying = true;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   requestId = window.requestAnimationFrame(draw);
@@ -200,9 +200,7 @@ function startVideo(): void {
  * @hidden
  */
 function stopVideo(): void {
-  if (videoIsLoaded && !videoIsPlaying) {
-    return;
-  }
+  if (!videoIsLoaded || !videoIsPlaying) return;
   videoIsPlaying = false;
   window.cancelAnimationFrame(requestId);
 }
@@ -223,7 +221,6 @@ function loadMedia(): void {
     .getUserMedia({ video: true })
     .then((stream) => {
       videoElement.srcObject = stream;
-      videoIsLoaded = true;
     })
     .catch((error) => {
       const errorMessage = `${error.name}: ${error.message}`;
@@ -334,6 +331,7 @@ function init(
   if (context == null) throw new Error('Canvas context should not be null.');
   canvasRenderingContext = context;
 
+  videoIsLoaded = true;
   setupData();
   loadMedia();
   queue();

--- a/src/bundles/pix_n_flix/functions.ts
+++ b/src/bundles/pix_n_flix/functions.ts
@@ -56,7 +56,6 @@ let filter: Filter = copy_image;
 let initialised: boolean = false;
 let toRunLateQueue: boolean = false;
 let videoIsPlaying: boolean = false;
-let videoIsLoaded: boolean = false;
 
 let FPS: number = DEFAULT_FPS;
 let requestId: number;

--- a/src/bundles/pix_n_flix/functions.ts
+++ b/src/bundles/pix_n_flix/functions.ts
@@ -60,15 +60,6 @@ let requestId: number;
 let startTime: number;
 let numberOfFrames: number = 0;
 
-// Water Leakage Experiments
-let renderCount: number = 0;
-const randID: number = Math.floor(Math.random() * 1000);
-function incrementRenderCount() {
-  renderCount += 1;
-  // eslint-disable-next-line no-console
-  console.log(randID, renderCount);
-}
-
 // =============================================================================
 // Module's Private Functions
 // =============================================================================
@@ -197,14 +188,9 @@ function draw(timestamp: number): void {
       if (numberOfFrames === 1) {
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         stopVideo();
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        // deinit();
-        // eslint-disable-next-line no-console
-        console.log('Disabling video');
       }
       numberOfFrames -= 1;
     }
-    incrementRenderCount();
   }
 }
 
@@ -348,8 +334,6 @@ function init(
   canvas: CanvasElement,
   _errorLogger: ErrorLogger
 ): number[] {
-  // eslint-disable-next-line no-console
-  console.log('Initialising', randID);
   videoElement = video;
   canvasElement = canvas;
   errorLogger = _errorLogger;
@@ -374,9 +358,6 @@ function deinit(): void {
   if (!stream) {
     return;
   }
-  // eslint-disable-next-line no-console
-  console.log('Deinitializing', randID);
-
   stream.getTracks().forEach((track) => {
     track.stop();
   });
@@ -579,11 +560,11 @@ export function set_fps(fps: number): void {
 }
 
 /**
- * Sets number of frames to display before cutting the video.
+ * Sets number of frames to display before pausing the video.
  * Note: Any value <= 0 will be taken to be indefinite number of frames (Default)
  *
- * @param nframes Number of frames to display before the video stream cuts.
+ * @param nframes Integer number of frames to display before the video is paused.
  */
-export function cut_at(nframes: number): void {
+export function pause_at(nframes: number): void {
   numberOfFrames = nframes;
 }

--- a/src/bundles/pix_n_flix/functions.ts
+++ b/src/bundles/pix_n_flix/functions.ts
@@ -53,7 +53,6 @@ const temporaryPixels: Pixels = [];
 // eslint-disable-next-line @typescript-eslint/no-use-before-define
 let filter: Filter = copy_image;
 
-let initialised: boolean = false;
 let toRunLateQueue: boolean = false;
 let videoIsPlaying: boolean = false;
 
@@ -194,7 +193,7 @@ function draw(timestamp: number): void {
 
 /** @hidden */
 function startVideo(): void {
-  if (!initialised || videoIsPlaying) return;
+  if (videoIsPlaying) return;
   videoIsPlaying = true;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   requestId = window.requestAnimationFrame(draw);
@@ -206,7 +205,7 @@ function startVideo(): void {
  * @hidden
  */
 function stopVideo(): void {
-  if (!initialised || !videoIsPlaying) return;
+  if (!videoIsPlaying) return;
   videoIsPlaying = false;
   window.cancelAnimationFrame(requestId);
 }
@@ -321,7 +320,7 @@ function enqueue(funcToAdd: Queue): void {
   };
 }
 
-// Queue is runned after media has properly loaded
+// lateQueue is runned after media has properly loaded
 let lateQueue: Queue = () => {};
 
 // adds function to the lateQueue
@@ -351,7 +350,6 @@ function init(
   if (context == null) throw new Error('Canvas context should not be null.');
   canvasRenderingContext = context;
 
-  initialised = true;
   setupData();
   loadMedia();
   queue();
@@ -369,7 +367,6 @@ function deinit(): void {
   if (!stream) {
     return;
   }
-  initialised = false;
   stream.getTracks().forEach((track) => {
     track.stop();
   });
@@ -541,11 +538,11 @@ export function compose_filter(filter1: Filter, filter2: Filter): Filter {
 }
 
 /**
- * Takes a snapshot of image after a set delay.
+ * Pauses the video after a set delay.
  *
- * @param delay Delay in ms before a snapshot is taken
+ * @param delay Delay in ms after the video starts.
  */
-export function snapshot(delay: number): void {
+export function pause_after(delay: number): void {
   // prevent negative delays
   lateEnqueue(() => setTimeout(stopVideo, delay >= 0 ? delay : -delay));
 }
@@ -569,14 +566,4 @@ export function set_dimensions(width: number, height: number): void {
  */
 export function set_fps(fps: number): void {
   enqueue(() => updateFPS(fps));
-}
-
-/**
- * Stops the video after a set delay.
- *
- * @param delay Delay in ms after the video starts
- */
-export function stop_video_after(delay: number): void {
-  // prevent negative delays
-  lateEnqueue(() => setTimeout(deinit, delay >= 0 ? delay : -delay));
 }

--- a/src/bundles/pix_n_flix/index.ts
+++ b/src/bundles/pix_n_flix/index.ts
@@ -14,6 +14,7 @@ import {
   snapshot,
   set_dimensions,
   set_fps,
+  pause_at,
 } from './functions';
 
 /**
@@ -38,4 +39,5 @@ export default () => ({
   snapshot,
   set_dimensions,
   set_fps,
+  pause_at,
 });

--- a/src/bundles/pix_n_flix/index.ts
+++ b/src/bundles/pix_n_flix/index.ts
@@ -14,7 +14,7 @@ import {
   snapshot,
   set_dimensions,
   set_fps,
-  pause_at,
+  stop_video_after,
 } from './functions';
 
 /**
@@ -39,5 +39,5 @@ export default () => ({
   snapshot,
   set_dimensions,
   set_fps,
-  pause_at,
+  stop_video_after,
 });

--- a/src/bundles/pix_n_flix/index.ts
+++ b/src/bundles/pix_n_flix/index.ts
@@ -11,10 +11,9 @@ import {
   install_filter,
   reset_filter,
   compose_filter,
-  snapshot,
+  pause_after,
   set_dimensions,
   set_fps,
-  stop_video_after,
 } from './functions';
 
 /**
@@ -36,8 +35,7 @@ export default () => ({
   install_filter,
   reset_filter,
   compose_filter,
-  snapshot,
+  pause_after,
   set_dimensions,
   set_fps,
-  stop_video_after,
 });


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Added lateQueue variable. allows for running of function only when the video is first rendered properly. Allows for snapshot and stop_video_after to be accurate in timing.

Replaced stop_video_after and snapshot function with more appropriately named pause_after function that does what the previous snap_shot function does. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] When using stop_video_after(delay) function, the camera should turn off after a given delay and changing the option from live video to still image and back to live video should not cause lag.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
