### PR TITLE
Allowing modules to display result independent of evaluation result

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "classnames": "^2.3.1",
     "dayjs": "^1.10.4",
     "gl-matrix": "^3.3.0",
+    "js-slang": "^0.5.25",
     "lodash": "^4.17.21",
     "phaser": "^3.54.0",
     "react": "^17.0.2",

--- a/src/bundles/curve/curves_webgl.ts
+++ b/src/bundles/curve/curves_webgl.ts
@@ -6,6 +6,7 @@ let canvasElement: HTMLCanvasElement;
 let renderingContext: WebGLRenderingContext | null;
 let programs: ProgramInfo;
 let buffersInfo: BufferInfo;
+export const drawnCurves: ShapeDrawn[] = [];
 
 // Vertex shader program
 const vsS: string = `
@@ -340,7 +341,7 @@ export default function generateCurve(
     }
   }
 
-  return {
+  const drawnCurve = {
     toReplString: () => '<ShapeDrawn>',
     init: (canvas) => {
       canvasElement = canvas;
@@ -421,4 +422,7 @@ export default function generateCurve(
       );
     },
   };
+
+  drawnCurves.push(drawnCurve);
+  return drawnCurve;
 }

--- a/src/bundles/curve/curves_webgl.ts
+++ b/src/bundles/curve/curves_webgl.ts
@@ -405,7 +405,7 @@ export default function generateCurve(
         curveBuffer,
         curveColorBuffer,
       };
-      return space === '3D';
+      // return space === '3D';
     },
     redraw: (angle) => {
       if (!renderingContext) {
@@ -421,6 +421,7 @@ export default function generateCurve(
         angle
       );
     },
+    is3D: () => space === '3D',
   };
 
   drawnCurves.push(drawnCurve);

--- a/src/bundles/curve/functions.ts
+++ b/src/bundles/curve/functions.ts
@@ -50,9 +50,7 @@ import generateCurve from './curves_webgl';
 /**
  * Returns a function that turns a given Curve into a Drawing, by sampling the
  * Curve at `num` sample points and connecting each pair with a line.
- * When a program evaluates to a Drawing, the Source system displays it
- * graphically, in a window, instead of textually. The parts between (0,0) and
- * (1,1) of the resulting Drawing are shown in the window.
+ * The parts between (0,0) and (1,1) of the resulting Drawing are shown in the window.
  *
  * @param num determines the number of points, lower than 65535, to be sampled.
  * Including 0 and 1, there are `num + 1` evenly spaced sample points
@@ -68,11 +66,9 @@ export function draw_connected(num: number): RenderFunction {
 
 /**
  * Returns a function that turns a given Curve into a Drawing, by sampling the
- * Curve at `num` sample points and connecting each pair with a line.
- * When a program evaluates to a Drawing, the Source system displays it
- * graphically, in a window, instead of textually. The Drawing is translated and
- * stretched/shrunk to show the full curve and maximize its width and height, with
- * some padding.
+ * Curve at `num` sample points and connecting each pair with a line. The Drawing is
+ * translated and stretched/shrunk to show the full curve and maximize its width
+ * and height, with some padding.
  *
  * @param num determines the number of points, lower than 65535, to be sampled.
  * Including 0 and 1, there are `num + 1` evenly spaced sample points
@@ -88,11 +84,9 @@ export function draw_connected_full_view(num: number): RenderFunction {
 
 /**
  * Returns a function that turns a given Curve into a Drawing, by sampling the
- * Curve at `num` sample points and connecting each pair with a line.
- * When a program evaluates to a Drawing, the Source system displays it
- * graphically, in a window, instead of textually. The Drawing is translated
- * and scaled proportionally to show the full curve and maximize its size, with
- * some padding.
+ * Curve at `num` sample points and connecting each pair with a line. The Drawing
+ * is translated and scaled proportionally to show the full curve and maximize
+ * its size, with some padding.
  *
  * @param num determines the number of points, lower than 65535, to be sampled.
  * Including 0 and 1, there are `num + 1` evenly spaced sample points
@@ -111,10 +105,8 @@ export function draw_connected_full_view_proportional(
 /**
  * Returns a function that turns a given Curve into a Drawing, by sampling the
  * Curve at `num` sample points. The Drawing consists of isolated
- * points, and does not connect them. When a program evaluates to a Drawing,
- * the Source system displays it graphically, in a window, instead of textually.
- * The parts between (0,0) and (1,1) of the resulting Drawing are shown in the
- * window.
+ * points, and does not connect them. The parts between (0,0) and (1,1) of the
+ * resulting Drawing are shown in the window.
  *
  * @param num determines the number of points, lower than 65535, to be sampled.
  * Including 0 and 1,there are `num + 1` evenly spaced sample points
@@ -131,10 +123,9 @@ export function draw_points(num: number): RenderFunction {
 /**
  * Returns a function that turns a given Curve into a Drawing, by sampling the
  * Curve at `num` sample points. The Drawing consists of isolated
- * points, and does not connect them. When a program evaluates to a Drawing, the
- * Source system displays it graphically, in a window, instead of textually. The
- * Drawing is translated and stretched/shrunk to show the full curve and maximize
- * its width and height, with some padding.
+ * points, and does not connect them. The Drawing is translated and
+ * stretched/shrunk to show the full curve and maximize its width and height,
+ * with some padding.
  *
  * @param num determines the number of points, lower than 65535, to be sampled.
  * Including 0 and 1, there are `num + 1` evenly spaced sample points
@@ -151,10 +142,9 @@ export function draw_points_full_view(num: number): RenderFunction {
 /**
  * Returns a function that turns a given Curve into a Drawing, by sampling the
  * Curve at `num` sample points. The Drawing consists of isolated
- * points, and does not connect them. When a program evaluates to a Drawing, the
- * Source system displays it graphically, in a window, instead of textually. The
- * Drawing is translated and scaled proportionally with its size maximized to fit
- * entirely inside the window, with some padding.
+ * points, and does not connect them. The Drawing is translated and scaled
+ * proportionally with its size maximized to fit entirely inside the window,
+ * with some padding.
  *
  * @param num determines the number of points, lower than 65535, to be sampled.
  * Including 0 and 1, there are `num + 1` evenly spaced sample points
@@ -173,9 +163,8 @@ export function draw_points_full_view_proportional(
 /**
  * Returns a function that turns a given 3D Curve into a Drawing, by sampling
  * the 3D Curve at `num` sample points and connecting each pair with
- * a line. When a program evaluates to a Drawing, the Source system displays it
- * graphically, in a window, instead of textually. The parts between (0,0,0) and
- * (1,1,1) of the resulting Drawing are shown within the unit cube.
+ * a line. The parts between (0,0,0) and (1,1,1) of the resulting Drawing are
+ * shown within the unit cube.
  *
  * @param num determines the number of points, lower than 65535, to be sampled.
  * Including 0 and 1, there are `num + 1` evenly spaced sample points
@@ -192,10 +181,8 @@ export function draw_3D_connected(num: number): RenderFunction {
 /**
  * Returns a function that turns a given 3D Curve into a Drawing, by sampling
  * the 3D Curve at `num` sample points and connecting each pair with
- * a line. When a program evaluates to a Drawing, the Source system displays it
- * graphically, in a window, instead of textually. The Drawing is translated and
- * stretched/shrunk to show the full curve and maximize its width and height within
- * the cube.
+ * a line. The Drawing is translated and stretched/shrunk to show the full
+ * curve and maximize its width and height within the cube.
  *
  * @param num determines the number of points, lower than 65535, to be sampled.
  * Including 0 and 1, there are `num + 1` evenly spaced sample points
@@ -212,9 +199,8 @@ export function draw_3D_connected_full_view(num: number): RenderFunction {
 /**
  * Returns a function that turns a given 3D Curve into a Drawing, by sampling
  * the 3D Curve at `num` sample points and connecting each pair with
- * a line. When a program evaluates to a Drawing, the Source system displays it
- * graphically, in a window, instead of textually. The Drawing is translated and
- * scaled proportionally with its size maximized to fit entirely inside the cube.
+ * a line. The Drawing is translated and scaled proportionally with its size
+ * maximized to fit entirely inside the cube.
  *
  * @param num determines the number of points, lower than 65535, to be sampled.
  * Including 0 and 1, there are `num + 1` evenly spaced sample points
@@ -233,10 +219,8 @@ export function draw_3D_connected_full_view_proportional(
 /**
  * Returns a function that turns a given 3D Curve into a Drawing, by sampling
  * the 3D Curve at `num` sample points. The Drawing consists of
- * isolated points, and does not connect them. When a program evaluates to a
- * Drawing, the Source system displays it graphically, in a window, instead of
- * textually. The parts between (0,0,0) and (1,1,1) of the resulting Drawing are
- * shown within the unit cube.
+ * isolated points, and does not connect them. The parts between (0,0,0)
+ * and (1,1,1) of the resulting Drawing are shown within the unit cube.
  *
  * @param num determines the number of points, lower than 65535, to be sampled.
  * Including 0 and 1, there are `num + 1` evenly spaced sample points
@@ -253,10 +237,8 @@ export function draw_3D_points(num: number): RenderFunction {
 /**
  * Returns a function that turns a given 3D Curve into a Drawing, by sampling
  * the 3D Curve at `num` sample points. The Drawing consists of
- * isolated points, and does not connect them. When a program evaluates to a
- * Drawing, the Source system displays it graphically, in a window, instead of
- * textually. The Drawing is translated and stretched/shrunk to maximize its
- * size to fit entirely inside the cube.
+ * isolated points, and does not connect them. The Drawing is translated and
+ * stretched/shrunk to maximize its size to fit entirely inside the cube.
  *
  * @param num determines the number of points, lower than 65535, to be sampled.
  * Including 0 and 1, there are `num + 1` evenly spaced sample points
@@ -273,10 +255,8 @@ export function draw_3D_points_full_view(num: number): RenderFunction {
 /**
  * Returns a function that turns a given 3D Curve into a Drawing, by sampling
  * the 3D Curve at `num` sample points. The Drawing consists of
- * isolated points, and does not connect them. When a program evaluates to a
- * Drawing, the Source system displays it graphically, in a window, instead of
- * textually. The Drawing is translated and scaled proportionally with its size
- * maximized to fit entirely inside the cube.
+ * isolated points, and does not connect them. The Drawing is translated and
+ * scaled proportionally with its size maximized to fit entirely inside the cube.
  *
  * @param num determines the number of points, lower than 65535, to be sampled.
  * Including 0 and 1, there are `num + 1` evenly spaced sample points

--- a/src/bundles/curve/index.ts
+++ b/src/bundles/curve/index.ts
@@ -1,3 +1,4 @@
+import { Context } from 'js-slang';
 import {
   make_point,
   make_3D_point,
@@ -34,6 +35,8 @@ import {
   arc,
   invert,
 } from './functions';
+import { CurveModuleState } from './types';
+import { drawnCurves } from './curves_webgl';
 
 /**
  * Bundle for Source Academy Curves module
@@ -41,7 +44,39 @@ import {
  * @author Ng Yong Xiang
  */
 
-export default function curves() {
+export default function curves(context: Context) {
+  if (context == null) {
+    // eslint-disable-next-line no-alert
+    alert('Context is null on first evaluation for some reason');
+  }
+
+  if (context.modules != null) {
+    let moduleContext = context.modules.get('curve');
+
+    if (moduleContext == null) {
+      // If module context is null, create the context
+      moduleContext = {
+        tabs: [],
+        state: {
+          drawnCurves,
+        },
+      };
+
+      // Then update the context
+      context.modules.set('curve', moduleContext);
+    }
+
+    if (moduleContext.state == null) {
+      // If the module's state object is null, create it
+      moduleContext.state = {
+        drawnCurves,
+      };
+    } else {
+      // Otherwise update the drawnCurves array
+      (moduleContext.state as CurveModuleState).drawnCurves = drawnCurves;
+    }
+  }
+
   return {
     make_point,
     make_3D_point,

--- a/src/bundles/curve/index.ts
+++ b/src/bundles/curve/index.ts
@@ -1,4 +1,5 @@
-import { Context } from 'js-slang';
+import { ModuleContext } from 'js-slang';
+import { drawnCurves } from './curves_webgl';
 import {
   make_point,
   make_3D_point,
@@ -36,7 +37,6 @@ import {
   invert,
 } from './functions';
 import { CurveModuleState } from './types';
-import { drawnCurves } from './curves_webgl';
 
 /**
  * Bundle for Source Academy Curves module
@@ -44,37 +44,28 @@ import { drawnCurves } from './curves_webgl';
  * @author Ng Yong Xiang
  */
 
-export default function curves(context: Context) {
-  if (context == null) {
-    // eslint-disable-next-line no-alert
-    alert('Context is null on first evaluation for some reason');
-  }
+export default function curves(
+  params: any,
+  context: Map<string, ModuleContext>
+) {
+  // Update the module's global context
+  let moduleContext = context.get('curve');
 
-  if (context.modules != null) {
-    let moduleContext = context.modules.get('curve');
-
-    if (moduleContext == null) {
-      // If module context is null, create the context
-      moduleContext = {
-        tabs: [],
-        state: {
-          drawnCurves,
-        },
-      };
-
-      // Then update the context
-      context.modules.set('curve', moduleContext);
-    }
-
-    if (moduleContext.state == null) {
-      // If the module's state object is null, create it
-      moduleContext.state = {
+  if (moduleContext == null) {
+    moduleContext = {
+      tabs: [],
+      state: {
         drawnCurves,
-      };
-    } else {
-      // Otherwise update the drawnCurves array
-      (moduleContext.state as CurveModuleState).drawnCurves = drawnCurves;
-    }
+      },
+    };
+
+    context.set('curve', moduleContext);
+  } else if (moduleContext.state == null) {
+    moduleContext.state = {
+      drawnCurves,
+    };
+  } else {
+    (moduleContext.state as CurveModuleState).drawnCurves = drawnCurves;
   }
 
   return {

--- a/src/bundles/curve/types.ts
+++ b/src/bundles/curve/types.ts
@@ -1,3 +1,5 @@
+import { ModuleState } from 'js-slang';
+
 /** Encapsulates 3D point with RGB values. */
 export type Point = {
   x: number;
@@ -45,3 +47,11 @@ export type BufferInfo = {
   curveBuffer: WebGLBuffer | null;
   curveColorBuffer: WebGLBuffer | null;
 };
+
+export class CurveModuleState implements ModuleState {
+  constructor() {
+    this.drawnCurves = [];
+  }
+
+  public drawnCurves: ShapeDrawn[];
+}

--- a/src/bundles/curve/types.ts
+++ b/src/bundles/curve/types.ts
@@ -25,7 +25,7 @@ export type ShapeDrawn = {
   toReplString: () => string;
   /**
    * A series of actions to perform as initialization of the curve on the given
-   * canvas. Return a boolean indicating whether the rendering function is in 3D.
+   * canvas.
    */
   init: (canvas: HTMLCanvasElement) => void;
   /** Redraws the canvas with the given rotation angle. */

--- a/src/bundles/curve/types.ts
+++ b/src/bundles/curve/types.ts
@@ -27,9 +27,12 @@ export type ShapeDrawn = {
    * A series of actions to perform as initialization of the curve on the given
    * canvas. Return a boolean indicating whether the rendering function is in 3D.
    */
-  init: (canvas: HTMLCanvasElement) => boolean;
+  init: (canvas: HTMLCanvasElement) => void;
   /** Redraws the canvas with the given rotation angle. */
   redraw: (angle: number) => void;
+
+  /** Boolean value indicating if the curve is 3D */
+  is3D: () => boolean;
 };
 export type ProgramInfo = {
   program: WebGLProgram;

--- a/src/bundles/rune/functions.ts
+++ b/src/bundles/rune/functions.ts
@@ -26,6 +26,8 @@ import {
   copyRune,
 } from './runes_ops';
 
+export const drawnRunes: Rune[] = [];
+
 // =============================================================================
 // Basic Runes
 // =============================================================================
@@ -592,6 +594,8 @@ export function show(rune: Rune): Rune {
   const normalRune = copyRune(rune);
   normalRune.drawMethod = 'normal';
   normalRune.toReplString = () => '<RENDERING>';
+  drawnRunes.push(normalRune);
+
   return normalRune;
 }
 
@@ -606,6 +610,8 @@ export function anaglyph(rune: Rune): Rune {
   const analyphRune = copyRune(rune);
   analyphRune.drawMethod = 'anaglyph';
   analyphRune.toReplString = () => '<RENDERING>';
+  drawnRunes.push(analyphRune);
+
   return analyphRune;
 }
 
@@ -621,6 +627,8 @@ export function hollusion_magnitude(rune: Rune, magnitude: number = 0.1): Rune {
   hollusionRune.drawMethod = 'hollusion';
   hollusionRune.hollusionDistance = magnitude;
   hollusionRune.toReplString = () => '<RENDERING>';
+  drawnRunes.push(hollusionRune);
+
   return hollusionRune;
 }
 

--- a/src/bundles/rune/index.ts
+++ b/src/bundles/rune/index.ts
@@ -1,3 +1,4 @@
+import { ModuleContext } from 'js-slang';
 import {
   square,
   blank,
@@ -46,64 +47,91 @@ import {
   anaglyph,
   hollusion_magnitude,
   hollusion,
+  drawnRunes,
 } from './functions';
+import { RunesModuleState } from './types';
 
 /**
  * Bundle for Source Academy Runes module
  * @author Hou Ruomu
  */
 
-export default () => ({
-  square,
-  blank,
-  rcross,
-  sail,
-  triangle,
-  corner,
-  nova,
-  circle,
-  heart,
-  pentagram,
-  ribbon,
+export default function runes(
+  params: Map<string, any>,
+  context: Map<string, ModuleContext>
+) {
+  // Update the module's global context
+  let moduleContext = context.get('rune');
 
-  from_url,
+  if (moduleContext == null) {
+    moduleContext = {
+      tabs: [],
+      state: {
+        drawnRunes,
+      },
+    };
 
-  scale_independent,
-  scale,
-  translate,
-  rotate,
-  stack_frac,
-  stack,
-  stackn,
-  quarter_turn_left,
-  quarter_turn_right,
-  turn_upside_down,
-  beside_frac,
-  beside,
-  flip_vert,
-  flip_horiz,
-  make_cross,
-  repeat_pattern,
+    context.set('rune', moduleContext);
+  } else if (moduleContext.state == null) {
+    moduleContext.state = {
+      drawnRunes,
+    };
+  } else {
+    (moduleContext.state as RunesModuleState).drawnRunes = drawnRunes;
+  }
 
-  overlay_frac,
-  overlay,
+  return {
+    square,
+    blank,
+    rcross,
+    sail,
+    triangle,
+    corner,
+    nova,
+    circle,
+    heart,
+    pentagram,
+    ribbon,
 
-  color,
-  random_color,
-  red,
-  pink,
-  purple,
-  indigo,
-  blue,
-  green,
-  yellow,
-  orange,
-  brown,
-  black,
-  white,
+    from_url,
 
-  show,
-  anaglyph,
-  hollusion_magnitude,
-  hollusion,
-});
+    scale_independent,
+    scale,
+    translate,
+    rotate,
+    stack_frac,
+    stack,
+    stackn,
+    quarter_turn_left,
+    quarter_turn_right,
+    turn_upside_down,
+    beside_frac,
+    beside,
+    flip_vert,
+    flip_horiz,
+    make_cross,
+    repeat_pattern,
+
+    overlay_frac,
+    overlay,
+
+    color,
+    random_color,
+    red,
+    pink,
+    purple,
+    indigo,
+    blue,
+    green,
+    yellow,
+    orange,
+    brown,
+    black,
+    white,
+
+    show,
+    anaglyph,
+    hollusion_magnitude,
+    hollusion,
+  };
+}

--- a/src/bundles/rune/types.ts
+++ b/src/bundles/rune/types.ts
@@ -1,4 +1,5 @@
 import { mat4 } from 'gl-matrix';
+import { ModuleState } from 'js-slang';
 
 /**
  * The basic data-representation of a Rune. When the Rune is drawn, every 3 consecutive vertex will form a triangle.
@@ -22,3 +23,11 @@ export type FrameBufferWithTexture = {
   framebuffer: WebGLFramebuffer;
   texture: WebGLTexture;
 };
+
+export class RunesModuleState implements ModuleState {
+  constructor() {
+    this.drawnRunes = [];
+  }
+
+  public drawnRunes: Rune[];
+}

--- a/src/bundles/sound/functions.ts
+++ b/src/bundles/sound/functions.ts
@@ -49,6 +49,7 @@ import { RIFFWAVE } from './riffwave';
 let audioElement: HTMLAudioElement;
 const FS: number = 44100; // Output sample rate
 const fourier_expansion_level: number = 5; // fourier expansion level
+export const audioPlayed: AudioPlayed[] = [];
 
 // Singular audio context for all playback functions
 let audioplayer: AudioContext;
@@ -373,7 +374,7 @@ export function play(sound: Sound): AudioPlayed {
       isPlaying = false;
     };
 
-    return {
+    const soundToPlay = {
       toReplString: () => `<AudioPlayed>`,
       init: (audio_elem) => {
         audioElement = audio_elem;
@@ -384,6 +385,8 @@ export function play(sound: Sound): AudioPlayed {
         return true;
       },
     };
+    audioPlayed.push(soundToPlay);
+    return soundToPlay;
   }
 }
 

--- a/src/bundles/sound/index.ts
+++ b/src/bundles/sound/index.ts
@@ -1,3 +1,4 @@
+import { ModuleContext } from 'js-slang';
 import {
   // Constructor/Accessors/Typecheck
   make_sound,
@@ -35,9 +36,31 @@ import {
   piano,
   trombone,
   violin,
+  audioPlayed,
 } from './functions';
+import { SoundsModuleState } from './types';
 
-export default function sounds() {
+export default function sounds(params, context: Map<string, ModuleContext>) {
+  // Update the module's global context
+  let moduleContext = context.get('sound');
+
+  if (moduleContext == null) {
+    moduleContext = {
+      tabs: [],
+      state: {
+        audioPlayed,
+      },
+    };
+
+    context.set('sound', moduleContext);
+  } else if (moduleContext.state == null) {
+    moduleContext.state = {
+      audioPlayed,
+    };
+  } else {
+    (moduleContext.state as SoundsModuleState).audioPlayed = audioPlayed;
+  }
+
   return {
     // Constructor/Accessors/Typecheck
     make_sound,

--- a/src/bundles/sound/types.ts
+++ b/src/bundles/sound/types.ts
@@ -1,3 +1,5 @@
+import { ModuleState } from 'js-slang';
+
 /* eslint-disable no-unused-vars */
 export type Pair<H, T> = [H, T];
 export type EmptyList = null;
@@ -16,3 +18,11 @@ export type AudioPlayed = {
   toReplString: () => string;
   init: (audio: HTMLAudioElement) => boolean;
 };
+
+export class SoundsModuleState implements ModuleState {
+  constructor() {
+    this.audioPlayed = [];
+  }
+
+  public audioPlayed: AudioPlayed[];
+}

--- a/src/tabs/Curve/curve_canvas.tsx
+++ b/src/tabs/Curve/curve_canvas.tsx
@@ -1,0 +1,28 @@
+/* eslint-disable react/destructuring-assignment */
+import React from 'react';
+import { CurveCanvasProps } from './types';
+
+type State = {};
+
+/**
+ * CurveCanvas used for 2D curves
+ */
+export default class CurveCanvas extends React.Component<
+  CurveCanvasProps,
+  State
+> {
+  public render() {
+    return (
+      <canvas
+        ref={(r) => {
+          if (r) {
+            this.props.curve.init(r);
+            this.props.curve.redraw(0);
+          }
+        }}
+        height={500}
+        width={500}
+      />
+    );
+  }
+}

--- a/src/tabs/Curve/curve_canvas3d.tsx
+++ b/src/tabs/Curve/curve_canvas3d.tsx
@@ -1,0 +1,153 @@
+/* eslint-disable react/destructuring-assignment */
+import { Slider, Button, Icon } from '@blueprintjs/core';
+import React from 'react';
+import { CurveCanvasProps } from './types';
+
+type State = {
+  /**
+   * Slider component reflects this value. This value is also passed in as
+   * argument to render curves.
+   */
+  rotationAngle: number;
+
+  /**
+   * Set to true by default. Slider updates this value to false when interacted
+   * with. Recursive `autoRotate()` checks for this value to decide whether to
+   * stop recursion. Button checks for this value to decide whether clicking the
+   * button takes effect, for countering spam-clicking.
+   */
+  isRotating: boolean;
+};
+
+/**
+ * 3D Version of the CurveCanvas to include the rotation angle slider
+ * and play button
+ */
+export default class CurveCanvas3D extends React.Component<
+  CurveCanvasProps,
+  State
+> {
+  private $canvas: HTMLCanvasElement | null;
+
+  constructor(props) {
+    super(props);
+
+    this.$canvas = null;
+    this.state = {
+      rotationAngle: 0,
+      isRotating: false,
+    };
+  }
+
+  public componentDidMount() {
+    if (this.$canvas) {
+      this.props.curve.init(this.$canvas);
+      this.props.curve.redraw(this.state.rotationAngle);
+    }
+  }
+
+  /**
+   * Event handler for slider component. Updates the canvas for any change in
+   * rotation.
+   *
+   * @param newValue new rotation angle
+   */
+  private onChangeHandler = (newValue: number) => {
+    this.setState(
+      (prevState) => ({
+        ...prevState,
+        rotationAngle: newValue,
+        isRotating: false,
+      }),
+      () => {
+        if (this.$canvas) {
+          this.props.curve.redraw(newValue);
+        }
+      }
+    );
+  };
+
+  /**
+   * Event handler for play button. Starts automated rotation by calling
+   * `autoRotate()`.
+   */
+  private onClickHandler = () => {
+    if (this.$canvas && !this.state.isRotating) {
+      this.setState(
+        (prevState) => ({
+          ...prevState,
+          isRotating: true,
+        }),
+        () => {
+          this.autoRotate();
+        }
+      );
+    }
+  };
+
+  /**
+   * Environment where `requestAnimationFrame` is called.
+   */
+  private autoRotate = () => {
+    if (this.$canvas && this.state.isRotating) {
+      this.setState(
+        (prevState) => ({
+          ...prevState,
+          rotationAngle:
+            prevState.rotationAngle >= 2 * Math.PI
+              ? 0
+              : prevState.rotationAngle + 0.005,
+        }),
+        () => {
+          this.props.curve.redraw(this.state.rotationAngle);
+          window.requestAnimationFrame(this.autoRotate);
+        }
+      );
+    }
+  };
+
+  public render() {
+    return (
+      <div>
+        <canvas
+          ref={(r) => {
+            if (r) {
+              this.$canvas = r;
+              this.props.curve.init(this.$canvas);
+              this.props.curve.redraw(this.state.rotationAngle);
+            }
+          }}
+          height={500}
+          width={500}
+        />
+        <div
+          style={{
+            display: 'flex',
+            padding: '10px',
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <Slider
+            value={this.state.rotationAngle}
+            stepSize={0.01}
+            labelValues={[0, 2 * Math.PI]}
+            labelRenderer={false}
+            min={0}
+            max={2 * Math.PI}
+            onChange={this.onChangeHandler}
+          />
+          <Button
+            style={{
+              marginLeft: '20px',
+            }}
+            onClick={this.onClickHandler}
+          >
+            <Icon icon='play' />
+          </Button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/tabs/Curve/index.tsx
+++ b/src/tabs/Curve/index.tsx
@@ -1,15 +1,6 @@
 import { Button } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import React from 'react';
-/*
- * Cannot import directly from react-hotkeys for some unknown reason
- * Referring to the fix posted here: https://github.com/evanw/esbuild/issues/1455
- */
-import {
-  configure,
-  GlobalHotKeys,
-  // eslint-disable-next-line import/extensions
-} from 'react-hotkeys/es/react-hotkeys.production.min.js';
 import { CurveModuleState, ShapeDrawn } from '../../bundles/curve/types';
 import { DebuggerContext } from '../../type_helpers';
 import CurveCanvas from './curve_canvas';
@@ -33,11 +24,6 @@ type CurvesTabState = {
   currentStep: number;
 };
 
-const visualizerKeyMap = {
-  PREVIOUS_STEP: 'left',
-  NEXT_STEP: 'right',
-};
-
 /* eslint-disable react/destructuring-assignment */
 class WebGLCanvas extends React.Component<CurvesTabProps, CurvesTabState> {
   private curvesToDraw: ShapeDrawn[];
@@ -57,17 +43,6 @@ class WebGLCanvas extends React.Component<CurvesTabProps, CurvesTabState> {
     }
   }
 
-  public componentDidMount() {
-    // Set up GlobalHotKeys
-    configure({
-      ignoreEventsCondition: (event) =>
-        (event.key === 'ArrowLeft' && this.firstStep()) ||
-        (event.key === 'ArrowRight' && this.finalStep()),
-      ignoreRepeatedEventsWhenKeyHeldDown: false,
-      stopEventPropagationAfterIgnoring: false,
-    });
-  }
-
   private firstStep = () => this.state.currentStep === 0;
 
   private finalStep = () =>
@@ -82,15 +57,10 @@ class WebGLCanvas extends React.Component<CurvesTabProps, CurvesTabState> {
   };
 
   public render() {
-    const visualizerHandlers = {
-      PREVIOUS_STEP: this.onPrevButtonClick,
-      NEXT_STEP: this.onNextButtonClick,
-    };
-
     const curveToDraw = this.curvesToDraw[this.state.currentStep];
 
     return (
-      <GlobalHotKeys keyMap={visualizerKeyMap} handlers={visualizerHandlers}>
+      <div>
         {this.curvesToDraw.length > 1 ? (
           <div
             style={{
@@ -148,7 +118,7 @@ class WebGLCanvas extends React.Component<CurvesTabProps, CurvesTabState> {
             <CurveCanvas curve={curveToDraw} />
           )}
         </div>
-      </GlobalHotKeys>
+      </div>
     );
   }
 }
@@ -168,6 +138,6 @@ export default {
     return moduleState.drawnCurves.length > 0;
   },
   body: (context: DebuggerContext) => <WebGLCanvas context={context} />,
-  label: 'Curve Canvas',
+  label: 'Curves Tab',
   iconName: 'media', // See https://blueprintjs.com/docs/#icons for more options
 };

--- a/src/tabs/Curve/types.ts
+++ b/src/tabs/Curve/types.ts
@@ -1,0 +1,7 @@
+import { ShapeDrawn } from '../../bundles/curve/types';
+
+export type CurveCanvasProps = {
+  children?: never;
+  className?: never;
+  curve: ShapeDrawn;
+};

--- a/src/type_helpers.ts
+++ b/src/type_helpers.ts
@@ -1,0 +1,13 @@
+import { Context } from 'js-slang';
+
+/**
+ * DebuggerContext type used by frontend
+ * to assist typing information
+ */
+export type DebuggerContext = {
+  result: any;
+  lastDebuggerResult: any;
+  code: string;
+  context: Context;
+  workspaceLocation?: any;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1335,6 +1335,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@joeychenofficial/alt-ergo-modified@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@joeychenofficial/alt-ergo-modified/-/alt-ergo-modified-2.4.0.tgz#27aec0cbed8ab4e2f0dad6feb4f0c9766ac3132f"
+  integrity sha512-58b0K8pNUVZXGbua4IJQ+1K+E+jz3MkhDazZaaeKlD+sOLYR9iTHIbicV/I5K16ivYW6R9lONiT3dz8rMeFJ1w==
+
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents":
   version "2.1.8-no-fsevents"
   resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.tgz#da7c3996b8e6e19ebd14d82eaced2313e7769f9b"
@@ -1545,6 +1550,11 @@
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
+"@types/estree@0.0.50":
+  version "0.0.50"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
+  integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
 
 "@types/fs-extra@^8.0.1":
   version "8.1.1"
@@ -1805,15 +1815,32 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
   integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
 
+acorn-loose@^8.0.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/acorn-loose/-/acorn-loose-8.3.0.tgz#0cd62461d21dce4f069785f8d3de136d5525029a"
+  integrity sha512-75lAs9H19ldmW+fAbyqHdjgdCrz0pWGXKmnqFoh8PyVd1L2RIb4RzYrSjmopeqv3E1G3/Pimu6GgLlrGbrkF7w==
+  dependencies:
+    acorn "^8.5.0"
+
 acorn-walk@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.0.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^7.1.1, acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.0.3, acorn@^8.5.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
 acorn@^8.0.5:
   version "8.1.0"
@@ -2075,6 +2102,11 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
+astring@^1.4.3:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/astring/-/astring-1.8.1.tgz#a91c4afd4af3523e11f31242a3d5d9af62bb6cc6"
+  integrity sha512-Aj3mbwVzj7Vve4I/v2JYOPFkCGM2YS7OqQTNSxmUR+LECRpokuPgAYghePgr6SALDo5bD5DlfbSaYjOzGJZOLQ==
+
 async-each@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
@@ -2219,6 +2251,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -2253,6 +2290,27 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
+bit-twiddle@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bit-twiddle/-/bit-twiddle-1.0.2.tgz#0c6c1fabe2b23d17173d9a61b7b7093eb9e1769e"
+  integrity sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4=
+
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 boxen@^5.0.0:
   version "5.0.0"
@@ -2340,6 +2398,14 @@ buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 builtin-modules@^3.1.0:
   version "3.2.0"
@@ -2465,6 +2531,11 @@ chokidar@^3.4.0:
     readdirp "~3.5.0"
   optionalDependencies:
     fsevents "~2.3.1"
+
+chownr@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
 chownr@^2.0.0:
   version "2.0.0"
@@ -2758,6 +2829,13 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
+decompress-response@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
+  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
+  dependencies:
+    mimic-response "^2.0.0"
+
 deep-equal@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
@@ -2769,6 +2847,11 @@ deep-equal@^1.1.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
+
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
@@ -2836,6 +2919,11 @@ depd@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -2960,7 +3048,7 @@ encoding@^0.1.12:
   dependencies:
     iconv-lite "^0.6.2"
 
-end-of-stream@^1.1.0:
+end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -3364,6 +3452,11 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+expand-template@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
+  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+
 expect@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/expect/-/expect-26.6.2.tgz#c6b996bf26bf3fe18b67b2d0f51fc981ba934417"
@@ -3473,6 +3566,11 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 filesize@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-6.1.0.tgz#e81bdaa780e2451d714d71c0d7a4f3238d37ad00"
@@ -3558,6 +3656,11 @@ fragment-cache@^0.2.1:
   integrity sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
   dependencies:
     map-cache "^0.2.2"
+
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
 fs-extra@^8.1.0:
   version "8.1.0"
@@ -3687,10 +3790,33 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
+  integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
+
 gl-matrix@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-3.3.0.tgz#232eef60b1c8b30a28cbbe75b2caf6c48fd6358b"
   integrity sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA==
+
+gl-wiretap@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/gl-wiretap/-/gl-wiretap-0.6.2.tgz#e4aa19622831088fbaa7e5a18d01768f7a3fb07c"
+  integrity sha512-fxy1XGiPkfzK+T3XKDbY7yaqMBmozCGvAFyTwaZA3imeZH83w7Hr3r3bYlMRWIyzMI/lDUvUMM/92LE2OwqFyQ==
+
+gl@^4.5.2:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/gl/-/gl-4.9.2.tgz#dd31cdaec7d3c4b6761648111e55531f86137821"
+  integrity sha512-lLYaicQxsRPxOnKWX9pIGmtKRuw0epvI089yl9uBvemYxR9xE01eRuXJgje1U0/06Df7bdOmmcW87IPOsu52Ow==
+  dependencies:
+    bindings "^1.5.0"
+    bit-twiddle "^1.0.2"
+    glsl-tokenizer "^2.0.2"
+    nan "^2.15.0"
+    node-abi "^2.30.1"
+    node-gyp "^7.1.2"
+    prebuild-install "^5.3.6"
 
 glob-parent@^3.1.0:
   version "3.1.0"
@@ -3775,6 +3901,29 @@ globby@^5.0.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+glsl-tokenizer@^2.0.2:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz#1c2e78c16589933c274ba278d0a63b370c5fee1a"
+  integrity sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==
+  dependencies:
+    through2 "^0.6.3"
+
+gpu-mock.js@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/gpu-mock.js/-/gpu-mock.js-1.3.1.tgz#f7deaa09da3f672762eda944ecf948fd2c4b1490"
+  integrity sha512-+lbp8rQ0p1nTa6Gk6HoLiw4yM6JTpql82U+nCF3sZbX4FJWP9PzzF1018dW8K+pbmqRmhLHbn6Bjc6i6tgUpbA==
+
+gpu.js@^2.10.4:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/gpu.js/-/gpu.js-2.15.0.tgz#378e835c247be2a6ad24eaf112a9c5a9221957a5"
+  integrity sha512-n2lrEuSuzLgzdzTBXzlnSR1G8f7ULnLS6I/4aHcuaLE6ZwuTYookd6SuwpmRWqfipzUSQfjPjOnbeD8bpfBtXg==
+  dependencies:
+    acorn "^7.1.1"
+    gl "^4.5.2"
+    gl-wiretap "^0.6.2"
+    gpu-mock.js "^1.3.0"
+    webgpu "^0.1.16"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.3, graceful-fs@^4.2.4:
   version "4.2.6"
@@ -4002,6 +4151,11 @@ iconv-lite@^0.6.2:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
+ieee754@^1.1.13:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
 ignore-walk@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
@@ -4058,7 +4212,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -4067,6 +4221,11 @@ inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+
+ini@~1.3.0:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 internal-slot@^1.0.3:
   version "1.0.3"
@@ -4379,6 +4538,11 @@ is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -4821,6 +4985,23 @@ jest@^26.6.3:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
+js-slang@^0.5.25:
+  version "0.5.25"
+  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.5.25.tgz#b25d8275bc425f9d17156dda4d07f4de1884c420"
+  integrity sha512-lxLxXxauqG91XYERY0p/ANjmUf02LuRCvzmekWhaypR27XsEsmPxllMJycllZ2oGZR8pJVFkiLSgihXyP3c/Jw==
+  dependencies:
+    "@joeychenofficial/alt-ergo-modified" "^2.4.0"
+    "@types/estree" "0.0.50"
+    acorn "^8.0.3"
+    acorn-loose "^8.0.0"
+    acorn-walk "^8.0.0"
+    astring "^1.4.3"
+    gpu.js "^2.10.4"
+    lodash "^4.17.20"
+    node-getopt "^0.3.2"
+    source-map "^0.7.3"
+    xmlhttprequest-ts "^1.0.1"
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -5238,6 +5419,11 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+mimic-response@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
+  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
+
 minimatch@^3.0.0, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -5245,7 +5431,7 @@ minimatch@^3.0.0, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -5320,6 +5506,11 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
+
 mkdirp@1.x, mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
@@ -5347,6 +5538,11 @@ ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+nan@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
+  integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -5364,6 +5560,11 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+napi-build-utils@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806"
+  integrity sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -5379,7 +5580,19 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-gyp@^7.1.0:
+node-abi@^2.30.1, node-abi@^2.7.0:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.30.1.tgz#c437d4b1fe0e285aaf290d45b45d4d7afedac4cf"
+  integrity sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==
+  dependencies:
+    semver "^5.4.1"
+
+node-getopt@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/node-getopt/-/node-getopt-0.3.2.tgz#57507cd22f6f69650aa99252304a842f1224e44c"
+  integrity sha512-yqkmYrMbK1wPrfz7mgeYvA4tBperLg9FQ4S3Sau3nSAkpOA0x0zC8nQ1siBwozy1f4SE8vq2n1WKv99r+PCa1Q==
+
+node-gyp@^7.1.0, node-gyp@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-7.1.2.tgz#21a810aebb187120251c3bcec979af1587b188ae"
   integrity sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==
@@ -5421,6 +5634,11 @@ node-releases@^1.1.70:
   version "1.1.71"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb"
   integrity sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
+
+noop-logger@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
+  integrity sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
 
 nopt@^5.0.0:
   version "5.0.0"
@@ -5531,7 +5749,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.1.2:
+npmlog@^4.0.1, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -5946,6 +6164,27 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
+prebuild-install@^5.3.6:
+  version "5.3.6"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.6.tgz#7c225568d864c71d89d07f8796042733a3f54291"
+  integrity sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==
+  dependencies:
+    detect-libc "^1.0.3"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^1.0.1"
+    node-abi "^2.7.0"
+    noop-logger "^0.1.1"
+    npmlog "^4.0.1"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^3.0.3"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+    which-pm-runs "^1.0.0"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -6068,6 +6307,16 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.2.tgz#abf64491e6ecf0f38a6502403d4cda04f372dfd3"
   integrity sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==
 
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
 react-dom@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
@@ -6180,7 +6429,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-"readable-stream@2 || 3":
+"readable-stream@2 || 3", readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -6188,6 +6437,16 @@ read-pkg@^5.2.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+"readable-stream@>=1.0.33-1 <1.1.0-0":
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
 
 readable-stream@^2.0.2, readable-stream@^2.0.6:
   version "2.3.7"
@@ -6590,7 +6849,7 @@ secure-compare@3.0.1:
   resolved "https://registry.yarnpkg.com/secure-compare/-/secure-compare-3.0.1.tgz#f1a0329b308b221fae37b9974f3d578d0ca999e3"
   integrity sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=
 
-"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -6693,6 +6952,20 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+
+simple-concat@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^3.0.3:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.1.tgz#cc7ba77cfbe761036fbfce3d021af25fc5584d55"
+  integrity sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==
+  dependencies:
+    decompress-response "^4.2.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
 
 sisteransi@^1.0.5:
   version "1.0.5"
@@ -6978,6 +7251,11 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -7038,6 +7316,11 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -7074,6 +7357,27 @@ table@^6.0.4:
     lodash "^4.17.20"
     slice-ansi "^4.0.0"
     string-width "^4.2.0"
+
+tar-fs@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
 
 tar@^6.0.2, tar@^6.1.0:
   version "6.1.0"
@@ -7129,6 +7433,14 @@ through2@3.0.1:
   integrity sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==
   dependencies:
     readable-stream "2 || 3"
+
+through2@^0.6.3:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
+  integrity sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=
+  dependencies:
+    readable-stream ">=1.0.33-1 <1.1.0-0"
+    xtend ">=4.0.0 <4.1.0-0"
 
 tmpl@1.0.x:
   version "1.0.4"
@@ -7222,7 +7534,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1:
+tslib@^1.8.1, tslib@^1.9.2:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -7541,6 +7853,11 @@ warning@^4.0.2, warning@^4.0.3:
   dependencies:
     loose-envify "^1.0.0"
 
+webgpu@^0.1.16:
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/webgpu/-/webgpu-0.1.16.tgz#dec416373e308181b28864b58c8a914461d7ceee"
+  integrity sha512-KAXn/f8lnL8o4B718zzdfi1l0nEWQpuoWlC1L5WM/svAbeHjShCEI0l5ZcZBEEUm9FF3ZTgRjWk8iwbJfnGKTA==
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -7587,6 +7904,11 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
+which-pm-runs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
+  integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
 which@^1.2.9:
   version "1.3.1"
@@ -7673,6 +7995,18 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xmlhttprequest-ts@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ts/-/xmlhttprequest-ts-1.0.1.tgz#7b3cb4a197aee38cf2d4f9dd6189d1d21f0835b2"
+  integrity sha1-ezy0oZeu44zy1PndYYnR0h8INbI=
+  dependencies:
+    tslib "^1.9.2"
+
+"xtend@>=4.0.0 <4.1.0-0":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
# Description

Originally motivated by #65. Calling `draw_connected` or `show` should display the corresponding curve and rune, independent of the program's evaluated result. The changes to the curve and rune modules in this pull request make this possible. The `sound` module's tab should also be displayed regardless of evaluation result if a call to `play()` was made

Refer to the changes to js-slang required for these changes: [Introduction of Modules Context objects](https://github.com/source-academy/js-slang/pull/1220)

Fixes # (issue)
- Fixes [Modules Issue #65](https://github.com/source-academy/modules/issues/65) - Drawing should not depend on evaluation result
    - This fix was extended to the `sound` module, allowing sounds played using `play()` to be played regardless of evaluation result. Currently, the first sound generated by the program will be played.
- Changes `curve` and `rune` to be able to display the results of multiple calls to `draw()` and `show()`, similar to how `draw_data` works.
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Import different modules and call their various functions:
```.js
import { draw_connected } from 'curve';
import { show, heart } from 'rune'; // Multiple import statements should not affect the program
import { unit_circle, make_point } from 'curve';

const line = x => t => make_point(x, t);
for (let i = 1; i <= 3; i = i + 1) {
     draw_connected(200)(line(i * 0.25));
}
show(heart);
0;
```
If the correct version of the frontend is used, it should be able to display all calls to `draw_connected` and `show`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
