### PR TITLE
[REPEAT]: Fix missing argument in documentation's example

### DIFF
--- a/src/bundles/repeat/functions.ts
+++ b/src/bundles/repeat/functions.ts
@@ -8,8 +8,8 @@
  * as applying the specified function to the same argument n times.
  * @example
  * ```typescript
- * const plusFour = repeat(x => x + 2);
- * plusFour(0); // Returns 4
+ * const plusTen = repeat(x => x + 2, 5);
+ * plusTen(0); // Returns 10
  * ```
  * @param func the function to be repeated
  * @param n the number of times to repeat the function


### PR DESCRIPTION
This small PR fixes an issue in the Repeat module's documentation, where the `repeat()` function's example is the same as that of `twice()` despite the former taking in two arguments instead of one. The missing argument has been added, and the example differentiated from the `twice()` example.

![image](https://user-images.githubusercontent.com/44526554/177127776-1318388d-22b2-4748-b67e-b20a8b6b7e17.png)

Fixes #109