### PR TITLE
make binary_tree consistent with SICP JS 2.3.3

### DIFF
--- a/src/bundles/binary_tree/functions.ts
+++ b/src/bundles/binary_tree/functions.ts
@@ -25,7 +25,7 @@ export function make_empty_tree(): BinaryTree {
  * @example
  * ```typescript
  * const tree = make_tree(1, make_empty_tree(), make_empty_tree());
- * display(tree); // Shows "[null, 1, null]" in the REPL
+ * display(tree); // Shows "[1, [null, [null, null]]]" in the REPL
  * ```
  * @param value Value to be stored in the node
  * @param left Left subtree of the node
@@ -37,7 +37,7 @@ export function make_tree(
   left: BinaryTree,
   right: BinaryTree,
 ): BinaryTree {
-  return [value, [left, right]];
+  return [value, [left, [right, null]]];
 }
 
 /**
@@ -60,7 +60,9 @@ export function is_tree(
 	  && Array.isArray(value[1])
   	  && value[1].length === 2
 	  && is_tree(value[1][0])
-	  && is_tree(value[1][1]));
+	  && value[1][1].length === 2
+	  && is_tree(value[1][1][0])
+	  && value[1][1][1] === null);
 }
 
 /**
@@ -137,8 +139,9 @@ export function right_branch(
   t: BinaryTree,
 ): BinaryTree {
   if (Array.isArray(t) && t.length === 2 &&
-      Array.isArray(t[1]) && t.length === 2) {
-    return t[1][1];
+      Array.isArray(t[1]) && t[1].length === 2 &&
+      Array.isArray(t[1][1]) && t[1][1].length === 2) {
+    return t[1][1][0];
   }
   throw new Error(
     `function right_branch expects binary tree, received: ${t}`,


### PR DESCRIPTION
# Description

Makes module `binary_tree` consistent with SICP JS 2.3.3

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

Manual testing:
```
import {
  entry, is_empty_tree, is_tree, left_branch,
  make_empty_tree, make_tree, right_branch
} from 'binary_tree';

const t = 
make_tree(
    1, 
    make_empty_tree(),
    make_tree(
        2,
        make_empty_tree(),
        make_empty_tree()));

display(t);
display(is_empty_tree(t));
display(is_tree(t));
display(entry(t));
display(right_branch(t));
display(left_branch(t));
display(left_branch(null));
```
gives
```
[1, [null, [[2, [null, [null, null]]], null]]]
false
true
1
[2, [null, [null, null]]]
null

Line 21: Error: function left_branch expects binary tree, received: null
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
