### PR TITLE
Update source path for create module yarn command

### DIFF
--- a/scripts/templates/module.ts
+++ b/scripts/templates/module.ts
@@ -32,7 +32,7 @@ export async function addNew() {
   const bundleDestination = `${SOURCE_PATH}/bundles/${moduleName}`;
   await fs.mkdir(bundleDestination, { recursive: true });
   await fs.copyFile(
-    `${cjsDirname(import.meta.url)}/__bundle__.ts`,
+    `${cjsDirname(import.meta.url)}/templates/__bundle__.ts`,
     `${bundleDestination}/index.ts`,
   );
   await fs.writeFile(


### PR DESCRIPTION
# Description

Changed source path for `__bundle__.ts` in create yarn command.
~~Also, command [here](https://github.com/source-academy/modules/wiki/Creating-a-New-Module) should be updated to `yarn run create`, but I can't figure out how this wiki thing works (I can't fork it nor make a PR?)~~

Update: Fixed wiki!

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Selecting the `module` option from `yarn run create` works now

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
