### PR TITLE
deployment: option --singlethread doesn't exist

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -23,7 +23,7 @@ jobs:
           
       - name: Build Modules 🔧
         run: |
-          yarn run build --single-thread
+          yarn run build
 
       - name: Deploy 🚀
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION

Trying to fix deployment script.

It had --single-thread option in
yarn run build
which doesn't seem to exist