### PR TITLE
Full default_js_slang function support to with js-slang pr

### DIFF
--- a/src/bundles/repl/functions.ts
+++ b/src/bundles/repl/functions.ts
@@ -16,10 +16,10 @@ context.moduleContexts.repl.state = INSTANCE;
  *
  * @category Main
  */
-export function invoke_repl(evalFunc: Function) {
+export function set_evaluator(evalFunc: Function) {
   if (!(evalFunc instanceof Function)) {
     const typeName = typeof (evalFunc);
-    throw new Error(`Wrong parameter type "${typeName}' in function "invoke_repl". It supposed to be a function and it's the entrance function of your metacircular evaulator.`);
+    throw new Error(`Wrong parameter type "${typeName}' in function "set_evaluator". It supposed to be a function and it's the entrance function of your metacircular evaulator.`);
   }
   INSTANCE.evalFunction = evalFunc;
   return {
@@ -70,17 +70,17 @@ export function set_font_size(font_size_px : number) {
 
 
 /**
- * When use this function as the entrance function in the parameter of "invoke_repl", the Programmable Repl will directly use the default js-slang interpreter to run your program in Programmable Repl editor. Do not directly call this function in your own code.
+ * When use this function as the entrance function in the parameter of "set_evaluator", the Programmable Repl will directly use the default js-slang interpreter to run your program in Programmable Repl editor. Do not directly call this function in your own code.
  * @param {program} Do not directly set this parameter in your code.
  * @param {safeKey} A parameter that is designed to prevent student from directly calling this function in Source language.
  *
  * @category Main
  */
 export function default_js_slang(program : string, safeKey : any) : any {
-  // When the function is normally called by invoke_repl function, safeKey is set to "document.body", which has a type "Element".
+  // When the function is normally called by set_evaluator function, safeKey is set to "document.body", which has a type "Element".
   // Students can not create objects and use HTML Elements in Source due to limitations and rules in Source, so they can't set the safeKey to a HTML Element, thus they can't use this function in Source.
   if (!(safeKey instanceof Element)) {
-    throw new Error('Invaild Call: Function "default_js_slang" can not be directly called by user\'s code in editor. You should use it as the parameter of the function "invoke_repl"');
+    throw new Error('Invaild Call: Function "default_js_slang" can not be directly called by user\'s code in editor. You should use it as the parameter of the function "set_evaluator"');
   }
   return INSTANCE.runInJsSlang(program);
 }

--- a/src/bundles/repl/index.ts
+++ b/src/bundles/repl/index.ts
@@ -9,7 +9,7 @@
 Example on usage:
   <*> Use with metacircular evaluator:
 
-      import { invoke_repl, module_display } from "repl";
+      import { set_evaluator, module_display } from "repl";
 
       const primitive_functions = list(
          ......
@@ -21,16 +21,16 @@ Example on usage:
         (your metacircular evaluator entry function)
       }
 
-      invoke_repl(parse_and_evaluate); // This can invoke the repl with your metacircular evaluator's evaluation entry
+      set_evaluator(parse_and_evaluate); // This can invoke the repl with your metacircular evaluator's evaluation entry
 
   =*=*=*=*=*= I'm the deluxe split line :) =*=*=*=*=*=
 
-  <*> Use with Source Academy's builtin js-slang (CURRENTLY NOT SUPPORTED IN PRODUCTION)
-      import { invoke_repl, default_js_slang, module_display } from "repl";  // Here you also need to import "module_display" to let the display result goes to the repl tab.
+  <*> Use with Source Academy's builtin js-slang
+      import { set_evaluator, default_js_slang, module_display } from "repl";  // Here you also need to import "module_display" along with "set_evaluator" and "default_js_slang".
 
-      invoke_repl(default_js_slang); // This can invoke the repl with Source Academy's builtin js-slang evaluation entry
+      set_evaluator(default_js_slang); // This can invoke the repl with Source Academy's builtin js-slang evaluation entry
 
-      (Note that you can't directly call "default_js_slang" in your own code. It should only be used as the parameter of "invoke_repl")
+      (Note that you can't directly call "default_js_slang" in your own code. It should only be used as the parameter of "set_evaluator")
 
   =*=*=*=*=*= I'm the deluxe split line :) =*=*=*=*=*=
 
@@ -65,9 +65,9 @@ Example on usage:
 */
 
 export {
-  invoke_repl,
+  set_evaluator,
   module_display,
   set_background_image,
   set_font_size,
-  // default_js_slang, // Commented because this is currently not supported in production version. Need changes in js-slang side to make it work.
+  default_js_slang,
 } from './functions';

--- a/src/bundles/repl/programmable_repl.ts
+++ b/src/bundles/repl/programmable_repl.ts
@@ -179,6 +179,8 @@ export class ProgrammableRepl {
     Needs hard-coded support from js-slang part for the "sourceRunner" function and "backupContext" property in the content object for this to work.
   */
   runInJsSlang(code : string) : string {
+    developmentLog('js-slang context:');
+    // console.log(context);
     const options : Partial<IOptions> = {
       originalMaxExecTime: 1000,
       scheduler: 'preemptive',
@@ -186,17 +188,13 @@ export class ProgrammableRepl {
       throwInfiniteLoops: true,
       useSubst: false,
     };
-    let jsslangContext = (context as any).backupContext;
-    const prelude = 'const display=(x)=>module_display(x);';
-    (context as any).sourceRunner(prelude, jsslangContext, true, options)
-      .then((preludeEvalResult) => {
-        developmentLog(preludeEvalResult);
-        if (preludeEvalResult.status === 'error') {
-          this.pushOutputString('[Warning] It seems that you havn\'t import the function "module_display" correctly when calling "invoke_repl". The runner will use the default js-slang builtin display function.', 'yellow');
-        }
-      });
-    let result : Promise<any> = (context as any).sourceRunner(code, jsslangContext, true, options);
-    developmentLog(result);
+    let jsslangContext = context.moduleContexts.repl.js_slang.context;
+    jsslangContext.prelude = 'const display=(x)=>module_display(x);';
+    jsslangContext.errors = []; // Here if I don't manually clear the "errors" array in context, the remaining errors from the last evaluation will stop the function "preprocessFileImports" in preprocessor.ts of js-slang thus stop the whole evaluation.
+    const sourceFile : Record<string, string> = {
+      '/ReplModuleUserCode.js': code,
+    };
+    let result : Promise<any> = context.moduleContexts.repl.js_slang.sourceFilesRunner(sourceFile, '/ReplModuleUserCode.js', jsslangContext, options);
     result.then((evalResult) => {
       if (evalResult.status !== 'error') {
         this.pushOutputString('js-slang program finished with value:', 'cyan');
@@ -207,7 +205,10 @@ export class ProgrammableRepl {
         const errorCount = errors.length;
         for (let i = 0; i < errorCount; i++) {
           const error = errors[i];
-          this.pushOutputString(`Line ${error.location.start.line}: ${error.type} Error: ${error.explain()}  (${error.elaborate()})`, 'red');
+          if (error.explain()
+            .indexOf('Name module_display not declared.') !== -1) {
+            this.pushOutputString('[Error] It seems that you havn\'t import the function "module_display" correctly when calling "set_evaluator" in Source Academy\'s main editor.', 'red');
+          } else this.pushOutputString(`Line ${error.location.start.line}: ${error.type} Error: ${error.explain()}  (${error.elaborate()})`, 'red');
         }
       }
       this.reRenderTab();

--- a/src/bundles/repl/programmable_repl.ts
+++ b/src/bundles/repl/programmable_repl.ts
@@ -188,13 +188,14 @@ export class ProgrammableRepl {
       throwInfiniteLoops: true,
       useSubst: false,
     };
-    let jsslangContext = context.moduleContexts.repl.js_slang.context;
+    const jsSlangStorage : any = (context.moduleContexts.repl as any).js_slang;
+    const jsslangContext = jsSlangStorage.context;
     jsslangContext.prelude = 'const display=(x)=>module_display(x);';
     jsslangContext.errors = []; // Here if I don't manually clear the "errors" array in context, the remaining errors from the last evaluation will stop the function "preprocessFileImports" in preprocessor.ts of js-slang thus stop the whole evaluation.
     const sourceFile : Record<string, string> = {
       '/ReplModuleUserCode.js': code,
     };
-    let result : Promise<any> = context.moduleContexts.repl.js_slang.sourceFilesRunner(sourceFile, '/ReplModuleUserCode.js', jsslangContext, options);
+    let result : Promise<any> = jsSlangStorage.sourceFilesRunner(sourceFile, '/ReplModuleUserCode.js', jsslangContext, options);
     result.then((evalResult) => {
       if (evalResult.status !== 'error') {
         this.pushOutputString('js-slang program finished with value:', 'cyan');


### PR DESCRIPTION
Here I made changes to my default_js_slang function to make it fully support with the latest evaluation logic of js-slang, also this pr is along with another pr in js-slang repo.
https://github.com/source-academy/js-slang/pull/1363
Also I renamed function "invoke_repl" to "set_evaluator" as Martin asked me to do so.