### PR TITLE
Fix documentation

### DIFF
--- a/src/bundles/physics_2d/index.ts
+++ b/src/bundles/physics_2d/index.ts
@@ -1,25 +1,27 @@
 /**
  * 2D Phyiscs simulation module for Source Academy.
  *
- * A <b>vector</b> is defined by its coordinates (x and y). The 2D vector is used to
+ * A **vector** is defined by its coordinates (x and y). The 2D vector is used to
  * represent direction, size, position, velocity and other physical attributes in
  * the physics world. Vector manipulation and transformations between vector and array
  * types are supported.
  *
- * A <b>force</b> is defined by its direction (a vector), its magnitude, duration and
+ * A **force** is defined by its direction (a vector), its magnitude, duration and
  * start time. A force is only actively applied if:
+ *
  * ```
  * diff > 0 && diff < duration, where diff is world time - start time
  * ```
  *
- * A <b>world</b> is the single physics world the module is based on.
+ * A **world** is the single physics world the module is based on.
  *
  * - `set_gravity` needs to be called once at the start of the program to initialize the world
  * and set the gravity.
  * - `make_ground` and `add_wall` are optional but recommended to be used to set boundaries
  * in the world.
  *
- * An <b>object</b> is initially defined in the add function by:
+ * An **object** is initially defined in the add function by:
+ *
  * - shape: which add function was used (e.g. `add_box_object`)
  * - position: initial position
  * - velocity: initial velocity
@@ -28,14 +30,17 @@
  * - isStatic (whether it is affected by physics)
  *
  * There are also additional attributes that can be set after an object has been added:
+ *
  * - density: mass per area of object
  * - friction: how much friction the object surface has
  *
  * There are two ways to apply a force on a given object:
+ *
  * - `apply_force`: applies a force to an object at a given object
  * - `apply_force_to_center`: applies a force to an object directly at its center
  *
  * Detection of collision and precise starting time are provided by:
+ *
  * - `is_touching`
  * - `impact_start_time`
  *
@@ -45,6 +50,7 @@
  * Visualization of the physics world can also be seen in the display tab.
 *
  * The following example simulates a free fall of a circle object.
+ *
  * ```
  * import { set_gravity, make_vector, add_circle_object, update_world } from "physics_2d";
  *

--- a/src/bundles/physics_2d/index.ts
+++ b/src/bundles/physics_2d/index.ts
@@ -6,15 +6,11 @@
  * the physics world. Vector manipulation and transformations between vector and array
  * types are supported.
  *
- * <br>
- *
  * A <b>force</b> is defined by its direction (a vector), its magnitude, duration and
  * start time. A force is only actively applied if:
  * ```
  * diff > 0 && diff < duration, where diff is world time - start time
  * ```
- *
- * <br>
  *
  * A <b>world</b> is the single physics world the module is based on.
  *
@@ -22,8 +18,6 @@
  * and set the gravity.
  * - `make_ground` and `add_wall` are optional but recommended to be used to set boundaries
  * in the world.
- *
- * <br>
  *
  * An <b>object</b> is initially defined in the add function by:
  * - shape: which add function was used (e.g. `add_box_object`)
@@ -45,15 +39,11 @@
  * - `is_touching`
  * - `impact_start_time`
  *
- * <br>
- *
  * After adding objects to the world, calling `update_world` will simulate the world.\
  * The suggested time step is 1/60 (seconds).
  *
  * Visualization of the physics world can also be seen in the display tab.
 *
- * <br>
- *
  * The following example simulates a free fall of a circle object.
  * ```
  * import { set_gravity, make_vector, add_circle_object, update_world } from "physics_2d";
@@ -71,7 +61,6 @@
  *   update_world(1/60);
  * }
  * ```
- * <br>
  *
  * @module physics_2d
  * @author Muhammad Fikri Bin Abdul Kalam

--- a/src/bundles/unity_academy/functions.ts
+++ b/src/bundles/unity_academy/functions.ts
@@ -13,7 +13,8 @@ import {
 
 
 /**
- * Load and initialize Unity Academy WebGL player and set it to 2D mode. All other functions (except Maths functions) in this module requires calling this function or init_unity_academy_3d first.<br>
+ * Load and initialize Unity Academy WebGL player and set it to 2D mode. All other functions (except Maths functions) in this module requires calling this function or init_unity_academy_3d first.
+ *
  * I recommand you just call this function at the beginning of your Source Unity program under the 'import' statements.
  *
  * @category Application Initialization
@@ -24,7 +25,8 @@ export function init_unity_academy_2d() : void {
 }
 
 /**
- * Load and initialize Unity Academy WebGL player and set it to 3D mode. All other functions (except Maths functions) in this module requires calling this function or init_unity_academy_2d first.<br>
+ * Load and initialize Unity Academy WebGL player and set it to 3D mode. All other functions (except Maths functions) in this module requires calling this function or init_unity_academy_2d first.
+ *
  * I recommand you just call this function at the beginning of your Source Unity program under the 'import' statements.
  *
  * @category Application Initialization
@@ -125,10 +127,10 @@ export function set_update(gameObjectIdentifier : GameObjectIdentifier, updateFu
 
 
 /**
- * Creates a new GameObject from an existing Prefab<br>
- * <br>
- * <b>3D mode only</b><br>
- * <br>
+ * Creates a new GameObject from an existing Prefab
+ *
+ * **3D mode only**
+ *
  * Available Prefab Information: <a href = 'https://unity-academy.s3.ap-southeast-1.amazonaws.com/webgl_assetbundles/prefab_info.html' rel="noopener noreferrer" target="_blank">Click Here</a>
  *
  * @param prefab_name The prefab name
@@ -146,10 +148,13 @@ export function instantiate(prefab_name : string) : GameObjectIdentifier {
 }
 
 /**
- * Creates a new 2D Sprite GameObject from an online image.<br>
- * The Sprite GameObject has a BoxCollider2D that matches its size by default. You may use `remove_collider_components` function to remove the default collider.<br><br>
- * Note that Unity Academy will use a HTTP GET request to download the image, which means that the HTTP response from the URL must allows CORS.<br><br>
- * <br><b>2D mode only</b>
+ * Creates a new 2D Sprite GameObject from an online image.
+ *
+ * The Sprite GameObject has a BoxCollider2D that matches its size by default. You may use `remove_collider_components` function to remove the default collider.
+ *
+ * Note that Unity Academy will use a HTTP GET request to download the image, which means that the HTTP response from the URL must allows CORS.
+ *
+ * **2D mode only**
  *
  * @param sourceImageUrl The image url for the sprite.
  * @return the identifier of the newly created GameObject
@@ -166,9 +171,10 @@ export function instantiate_sprite(sourceImageUrl : string) {
 }
 
 /**
- * Creates a new empty GameObject.<br>
- * <br>
- * An empty GameObject is invisible and only have transform properties by default.<br>
+ * Creates a new empty GameObject.
+ *
+ * An empty GameObject is invisible and only have transform properties by default.
+ *
  * You may use the empty GameObject to run some general game management code or use the position of the empty GameObject to represent a point in the scene that the rest of your codes can access and utilize.
  *
  * @return the identifier of the newly created GameObject
@@ -184,9 +190,12 @@ export function instantiate_empty() : GameObjectIdentifier {
 }
 
 /**
- * Returns the value of Time.deltaTime in Unity ( roughly saying it's about `1 / instant frame rate` )<br>
- * This should be useful when implementing timers or constant speed control in Update function.<br>
+ * Returns the value of Time.deltaTime in Unity ( roughly saying it's about `1 / instant frame rate` )
+ *
+ * This should be useful when implementing timers or constant speed control in Update function.
+ *
  * For example:
+ *
  * ```
  * function update(gameObject){
  *     const move_speed = 3;
@@ -194,9 +203,9 @@ export function instantiate_empty() : GameObjectIdentifier {
  * }
  * ```
  * By assigning the above code to a GameObject with `set_update`, that GameObject will move in a constant speed of 3 units along world +Z axis, ignoring the affect of unstable instant frame rate.
- * <br>
- * <br>
+ *
  * For more information, see https://docs.unity3d.com/ScriptReference/Time-deltaTime.html
+ *
  * @return the delta time value in decimal
  *
  * @category Common
@@ -208,9 +217,10 @@ export function delta_time() {
 }
 
 /**
- * Remove a GameObject<br>
- * Note that this won't remove the GameObject immediately, the actual removal will happen at the end of the current main cycle loop.<br>
- * <br>
+ * Remove a GameObject
+ *
+ * Note that this won't remove the GameObject immediately, the actual removal will happen at the end of the current main cycle loop.
+ *
  * For more information, see https://docs.unity3d.com/ScriptReference/Object.Destroy.html
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to destroy.
@@ -303,8 +313,9 @@ export function set_rotation_euler(gameObjectIdentifier : GameObjectIdentifier, 
 
 /**
  * Returns the scale (size factor) of a given GameObject
- * <br>
+ *
  * By default the scale of a GameObject is (1, 1, 1)
+ *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to get scale for.
  * @return the scale represented in an array with three elements: [x, y, z]
  *
@@ -319,7 +330,7 @@ export function get_scale(gameObjectIdentifier : GameObjectIdentifier) : Array<N
 
 /**
  * Set the scale (size) of a given GameObject
- * <br>
+ *
  * By default the scale of a GameObject is (1, 1, 1). Changing the scale of a GameObject along one axis will lead to a stretch or squeeze of the GameObject along that axis.
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to change scale for.
@@ -360,8 +371,10 @@ export function translate_world(gameObjectIdentifier : GameObjectIdentifier, x: 
 }
 
 /**
- * Moves a GameObject with given x, y and z values, <b>with respect to its local space</b>.<br>
- * The current rotation of the GameObject will affect the real direction of movement.<br>
+ * Moves a GameObject with given x, y and z values, **with respect to its local space**.
+ *
+ * The current rotation of the GameObject will affect the real direction of movement.
+ *
  * In Unity, usually, the direction of +Z axis denotes forward.
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to translate.
@@ -402,8 +415,10 @@ export function rotate_world(gameObjectIdentifier : GameObjectIdentifier, x: num
 }
 
 /**
- * Copy the position values from one GameObject to another GameObject along with delta values.<br><br>
- * Set the delta parameters to `Infinity` or `-Infinity` to remain the position of the destination GameObject on the corresponding axis unaffected.<br>
+ * Copy the position values from one GameObject to another GameObject along with delta values.
+ *
+ * Set the delta parameters to `Infinity` or `-Infinity` to remain the position of the destination GameObject on the corresponding axis unaffected.
+ *
  *
  * @param from The identifier for the GameObject that you want to copy position from.
  * @param to The identifier for the GameObject that you want to copy position to.
@@ -425,8 +440,10 @@ export function copy_position(from : GameObjectIdentifier, to : GameObjectIdenti
 }
 
 /**
- * Copy the rotation values (Euler angles) from one GameObject to another GameObject along with delta values.<br><br>
- * Set the delta parameters to `Infinity` or `-Infinity` to remain the rotation of the destination GameObject on the corresponding axis unaffected.<br>
+ * Copy the rotation values (Euler angles) from one GameObject to another GameObject along with delta values.
+ *
+ * Set the delta parameters to `Infinity` or `-Infinity` to remain the rotation of the destination GameObject on the corresponding axis unaffected.
+ *
  *
  * @param from The identifier for the GameObject that you want to copy rotation from.
  * @param to The identifier for the GameObject that you want to copy rotation to.
@@ -448,8 +465,10 @@ export function copy_rotation(from : GameObjectIdentifier, to : GameObjectIdenti
 }
 
 /**
- * Copy the scale values from one GameObject to another GameObject along with delta values.<br><br>
- * Set the delta parameters to `Infinity` or `-Infinity` to remain the scale of the destination GameObject on the corresponding axis unaffected.<br>
+ * Copy the scale values from one GameObject to another GameObject along with delta values.
+ *
+ * Set the delta parameters to `Infinity` or `-Infinity` to remain the scale of the destination GameObject on the corresponding axis unaffected.
+ *
  *
  * @param from The identifier for the GameObject that you want to copy scale from.
  * @param to The identifier for the GameObject that you want to copy scale to.
@@ -471,12 +490,13 @@ export function copy_scale(from : GameObjectIdentifier, to : GameObjectIdentifie
 }
 
 /**
- * Makes the GameObject "Look At" a given position.<br>
- * <b>3D mode only</b><br>
- * <br>
- * The +Z direction of the GameObject (which denotes forward in Unity's conventions) will pointing to the given position.<br>
- * <br>
- * For more information, see https://docs.unity3d.com/ScriptReference/Transform.LookAt.html<br>
+ * Makes the GameObject "Look At" a given position.
+ *
+ * **3D mode only**
+ *
+ * The +Z direction of the GameObject (which denotes forward in Unity's conventions) will pointing to the given position.
+ *
+ * For more information, see https://docs.unity3d.com/ScriptReference/Transform.LookAt.html
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you need to make it "look at" a position
  * @param x The X value of the "look at" position
@@ -527,9 +547,9 @@ function checkKeyCodeValidityAndToLowerCase(keyCode : string) : string {
 
 /**
  * When user presses a key on the keyboard or mouse button, this function will return true only at the frame when the key is just pressed down and return false afterwards.
- * <br>
- * <br>
+ *
  * For more information, see https://docs.unity3d.com/ScriptReference/Input.GetKeyDown.html
+ *
  * @return A boolean value equivalent to Input.GetKeyDown(keyCode) in Unity.
  *
  * @param keyCode The key to detact input for.
@@ -544,9 +564,9 @@ export function get_key_down(keyCode : string) : boolean {
 
 /**
  * When user presses a key on the keyboard or mouse button, this function will return true in every frame that the key is still being pressed and false otherwise.
- * <br>
- * <br>
+ *
  * For more information, see https://docs.unity3d.com/ScriptReference/Input.GetKey.html
+ *
  * @return A boolean value equivalent to Input.GetKey(keyCode) in Unity.
  *
  * @param keyCode The key to detact input for.
@@ -563,9 +583,9 @@ export function get_key(keyCode : string) : boolean {
 
 /**
  * When user releases a pressed key on the keyboard or mouse button, this function will return true only at the frame when the key is just released up and return false otherwise.
- * <br>
- * <br>
+ *
  * For more information, see https://docs.unity3d.com/ScriptReference/Input.GetKeyUp.html
+ *
  * @return A boolean value equivalent to Input.GetKeyUp(keyCode) in Unity.
  *
  * @param keyCode The key to detact input for.
@@ -579,10 +599,13 @@ export function get_key_up(keyCode : string) : boolean {
 }
 
 /**
- * Plays an Unity animation state with given name on the GameObject's animator. Note that not all game objects have Unity animations. You should ask the people who provided you the prefab asset bundle for available animation names assigned to the prefab.<br><br>
- * If you provide an invalid animator state name, this function will not take effect.<br><br>
- * <b>3D mode only</b><br><br>
- * [For Prefab Authors] Please follow these conventions if you are making humanoid prefabs (for example: any human-like characters): Name the standing animation state as "Idle" and name the walking animation state as "Walk" in Unity Animator.<br>
+ * Plays an Unity animation state with given name on the GameObject's animator. Note that not all game objects have Unity animations. You should ask the people who provided you the prefab asset bundle for available animation names assigned to the prefab.
+ *
+ * If you provide an invalid animator state name, this function will not take effect.
+ *
+ * **3D mode only**
+ *
+ * [For Prefab Authors] Please follow these conventions if you are making humanoid prefabs (for example: any human-like characters): Name the standing animation state as "Idle" and name the walking animation state as "Walk" in Unity Animator.
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to play the animation on.
  * @param animatorStateName The name for the animator state to play.
@@ -598,13 +621,14 @@ export function play_animator_state(gameObjectIdentifier : GameObjectIdentifier,
 }
 
 /**
- * Apply rigidbody (2D or 3D based on the current dimension mode) to the given game object to use Unity's physics engine<br>
- * <br><br>All other functions under the Physics - Rigidbody category require calling this function first on the applied game objects.
- * <br>
- * <br>
+ * Apply rigidbody (2D or 3D based on the current dimension mode) to the given game object to use Unity's physics engine
+ *
+ * All other functions under the Physics - Rigidbody category require calling this function first on the applied game objects.
+ *
  * For more information, see
- * <br>https://docs.unity3d.com/ScriptReference/Rigidbody.html (For 3D Mode) or
- * <br>https://docs.unity3d.com/ScriptReference/Rigidbody2D.html (For 2D Mode)
+ *
+ * - https://docs.unity3d.com/ScriptReference/Rigidbody.html (For 3D Mode) or
+ * - https://docs.unity3d.com/ScriptReference/Rigidbody2D.html (For 2D Mode)
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to apply rigidbody on.
  * @category Physics - Rigidbody
@@ -618,7 +642,8 @@ export function apply_rigidbody(gameObjectIdentifier : GameObjectIdentifier) : v
 
 /**
  * Returns the mass of the rigidbody attached on the game object.
- * <br><br>Usage of all physics functions under the Physics - Rigidbody category requires calling `apply_rigidbody` first on the applied game objects.
+ *
+ * Usage of all physics functions under the Physics - Rigidbody category requires calling `apply_rigidbody` first on the applied game objects.
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to get mass for.
  * @return The mass of the rigidbody attached on the GameObject
@@ -633,7 +658,8 @@ export function get_mass(gameObjectIdentifier : GameObjectIdentifier) : number {
 
 /**
  * Set the mass of the rigidbody attached on the game object.
- * <br><br>Usage of all physics functions under the Physics - Rigidbody category requires calling `apply_rigidbody` first on the applied game objects.
+ *
+ * Usage of all physics functions under the Physics - Rigidbody category requires calling `apply_rigidbody` first on the applied game objects.
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to change mass for.
  * @param mass The value for the new mass.
@@ -649,7 +675,8 @@ export function set_mass(gameObjectIdentifier : GameObjectIdentifier, mass : num
 
 /**
  * Returns the velocity of the rigidbody attached on the game object.
- * <br><br>Usage of all physics functions under the Physics - Rigidbody category requires calling `apply_rigidbody` first on the applied game objects.
+ *
+ * Usage of all physics functions under the Physics - Rigidbody category requires calling `apply_rigidbody` first on the applied game objects.
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to get velocity for.
  * @return the velocity at this moment represented in an array with three elements: [x, y, z]
@@ -664,7 +691,8 @@ export function get_velocity(gameObjectIdentifier : GameObjectIdentifier) : Arra
 
 /**
  * Set the (linear) velocity of the rigidbody attached on the game object.
- * <br><br>Usage of all physics functions under the Physics - Rigidbody category requires calling `apply_rigidbody` first on the applied game objects.
+ *
+ * Usage of all physics functions under the Physics - Rigidbody category requires calling `apply_rigidbody` first on the applied game objects.
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to change velocity for.
  * @param x The x component of the velocity vector.
@@ -684,8 +712,10 @@ export function set_velocity(gameObjectIdentifier : GameObjectIdentifier, x: num
 
 /**
  * Returns the angular velocity of the rigidbody attached on the game object.
- * <br><br>Usage of all physics functions under the Physics - Rigidbody category requires calling `apply_rigidbody` first on the applied game objects.
- * <br><br><b>2D Mode Special: </b>In 2D mode there is no angular velocity on X nor Y axis, so in the first two elements for the returned array will always be zero.
+ *
+ * Usage of all physics functions under the Physics - Rigidbody category requires calling `apply_rigidbody` first on the applied game objects.
+ *
+ * **2D Mode Special: **In 2D mode there is no angular velocity on X nor Y axis, so in the first two elements for the returned array will always be zero.
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to get angular velocity for.
  * @return the angular velocity at this moment represented in an array with three elements: [x, y, z]
@@ -700,8 +730,10 @@ export function get_angular_velocity(gameObjectIdentifier : GameObjectIdentifier
 
 /**
  * Set the angular velocity of the rigidbody attached on the game object.
- * <br><br>Usage of all physics functions under the Physics - Rigidbody category requires calling `apply_rigidbody` first on the applied game objects.
- * <br><br><b>2D Mode Special: </b>In 2D mode there is no angular velocity on X nor Y axis, so the value of the first two parameters for this function is ignored.
+ *
+ * Usage of all physics functions under the Physics - Rigidbody category requires calling `apply_rigidbody` first on the applied game objects.
+ *
+ * **2D Mode Special: **In 2D mode there is no angular velocity on X nor Y axis, so the value of the first two parameters for this function is ignored.
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to change angular velocity for.
  * @param x The x component of the angular velocity vector.
@@ -720,9 +752,11 @@ export function set_angular_velocity(gameObjectIdentifier : GameObjectIdentifier
 }
 
 /**
- * Set the drag (similar to air resistance) the rigidbody attached on the game object.<br>
+ * Set the drag (similar to air resistance) the rigidbody attached on the game object.
+ *
  * By default the drag is zero
- * <br><br>Usage of all physics functions under the Physics - Rigidbody category requires calling `apply_rigidbody` first on the applied game objects.
+ *
+ * Usage of all physics functions under the Physics - Rigidbody category requires calling `apply_rigidbody` first on the applied game objects.
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to change drag for.
  * @param value The value of the new drag.
@@ -737,9 +771,11 @@ export function set_drag(gameObjectIdentifier : GameObjectIdentifier, value: num
 }
 
 /**
- * Set the angular drag (similar to an air resistance that affects angular velocity) the rigidbody attached on the game object.<br>
+ * Set the angular drag (similar to an air resistance that affects angular velocity) the rigidbody attached on the game object.
+ *
  * By default the angular drag is 0.05
- * <br><br>Usage of all physics functions under the Physics - Rigidbody category requires calling `apply_rigidbody` first on the applied game objects.
+ *
+ * Usage of all physics functions under the Physics - Rigidbody category requires calling `apply_rigidbody` first on the applied game objects.
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to change angular drag for.
  * @param value The value of the new angular drag.
@@ -755,7 +791,8 @@ export function set_angular_drag(gameObjectIdentifier : GameObjectIdentifier, va
 
 /**
  * Set whether the rigidbody attached on the game object should calculate for gravity.
- * <br><br>Usage of all physics functions under the Physics - Rigidbody category requires calling `apply_rigidbody` first on the applied game objects.
+ *
+ * Usage of all physics functions under the Physics - Rigidbody category requires calling `apply_rigidbody` first on the applied game objects.
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to enable/disable gravity on its rigidbody.
  * @param {useGravity} Set to true if you want gravity to be applied on this rigidbody, false otherwise.
@@ -771,8 +808,9 @@ export function set_use_gravity(gameObjectIdentifier : GameObjectIdentifier, use
 
 
 /**
- * Add an impulse force on the Rigidbody attached on the GameObject, <b>using its mass</b>.
- * <br><br>Usage of all physics functions under the Physics category requires calling `apply_rigidbody` first on the applied game objects.
+ * Add an impulse force on the Rigidbody attached on the GameObject, **using its mass**.
+ *
+ * Usage of all physics functions under the Physics category requires calling `apply_rigidbody` first on the applied game objects.
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to add the force.
  * @param x The x component of the force vector.
@@ -791,9 +829,10 @@ export function add_impulse_force(gameObjectIdentifier : GameObjectIdentifier, x
 }
 
 /**
- * Removes all collider components directly attached on the given GameObject by default.<br>
- * <br>
- * You can use this function on GameObjects those you don't want them to collide with other GameObjects.<br>
+ * Removes all collider components directly attached on the given GameObject by default.
+ *
+ * You can use this function on GameObjects those you don't want them to collide with other GameObjects.
+ *
  * For example, you may use this on the background image sprite GameObject in 2D scene.
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to remove colliders for.
@@ -807,17 +846,18 @@ export function remove_collider_components(gameObjectIdentifier : GameObjectIden
 }
 
 /**
- * Set the lifecycle event function that will be called when the collider on this GameObject just starting colliding with another collider.<br>
- * <br>
- * The given function should contain two parameters. The first parameter refers to the binded GameObject and the second parameter refers to the other GameObject that collides with the binded GameObject (both parameters are GameObject identifiers).<br>
+ * Set the lifecycle event function that will be called when the collider on this GameObject just starting colliding with another collider.
+ *
+ * The given function should contain two parameters. The first parameter refers to the binded GameObject and the second parameter refers to the other GameObject that collides with the binded GameObject (both parameters are GameObject identifiers).
+ *
  * For example: `const myFunction = (self, other) => {...};`
- * <br>
+ *
  * Note that for collision detaction to happen, for the two colliding GameObjects, at least one GameObject should have a Rigidbody / Rigidbody2D component (called `apply_rigidbody` on the GameObject).
- * <br>
- * <br>
+ *
  * For more information, see
- * <br>https://docs.unity3d.com/ScriptReference/Collider.OnCollisionEnter.html (For 3D Mode) or
- * <br>https://docs.unity3d.com/ScriptReference/MonoBehaviour.OnCollisionEnter2D.html (For 2D Mode)
+ *
+ * - https://docs.unity3d.com/ScriptReference/Collider.OnCollisionEnter.html (For 3D Mode) or
+ * - https://docs.unity3d.com/ScriptReference/MonoBehaviour.OnCollisionEnter2D.html (For 2D Mode)
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to bind the lifecycle event function on.
  * @param eventFunction The lifecycle event function for handling this event.
@@ -833,17 +873,18 @@ export function on_collision_enter(gameObjectIdentifier : GameObjectIdentifier, 
 }
 
 /**
- * Set the lifecycle event function that will be called per frame when the collider on this GameObject is colliding with another collider.<br>
- * <br>
- * The given function should contain two parameters. The first parameter refers to the binded GameObject and the second parameter refers to the other GameObject that collides with the binded GameObject (both parameters are GameObject identifiers).<br>
+ * Set the lifecycle event function that will be called per frame when the collider on this GameObject is colliding with another collider.
+ *
+ * The given function should contain two parameters. The first parameter refers to the binded GameObject and the second parameter refers to the other GameObject that collides with the binded GameObject (both parameters are GameObject identifiers).
+ *
  * For example: `const myFunction = (self, other) => {...};`
- * <br>
+ *
  * Note that for collision detaction to happen, for the two colliding GameObjects, at least one GameObject should have a Rigidbody / Rigidbody2D component (called `apply_rigidbody` on the GameObject).
- * <br>
- * <br>
+ *
  * For more information, see
- * <br>https://docs.unity3d.com/ScriptReference/Collider.OnCollisionStay.html (For 3D Mode) or
- * <br>https://docs.unity3d.com/ScriptReference/MonoBehaviour.OnCollisionStay2D.html (For 2D Mode)
+ *
+ * - https://docs.unity3d.com/ScriptReference/Collider.OnCollisionStay.html (For 3D Mode) or
+ * - https://docs.unity3d.com/ScriptReference/MonoBehaviour.OnCollisionStay2D.html (For 2D Mode)
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to bind the lifecycle event function on.
  * @param eventFunction The lifecycle event function for handling this event.
@@ -859,17 +900,18 @@ export function on_collision_stay(gameObjectIdentifier : GameObjectIdentifier, e
 }
 
 /**
- * Set the lifecycle event function that will be called when the collider on this GameObject just stops colliding with another collider.<br>
- * <br>
- * The given function should contain two parameters. The first parameter refers to the binded GameObject and the second parameter refers to the other GameObject that collides with the binded GameObject (both parameters are GameObject identifiers).<br>
+ * Set the lifecycle event function that will be called when the collider on this GameObject just stops colliding with another collider.
+ *
+ * The given function should contain two parameters. The first parameter refers to the binded GameObject and the second parameter refers to the other GameObject that collides with the binded GameObject (both parameters are GameObject identifiers).
+ *
  * For example: `const myFunction = (self, other) => {...};`
- * <br>
+ *
  * Note that for collision detaction to happen, for the two colliding GameObjects, at least one GameObject should have a Rigidbody / Rigidbody2D component (called `apply_rigidbody` on the GameObject).
- * <br>
- * <br>
+ *
  * For more information, see
- * <br>https://docs.unity3d.com/ScriptReference/MonoBehaviour.OnCollisionExit.html (For 3D Mode) or
- * <br>https://docs.unity3d.com/ScriptReference/MonoBehaviour.OnCollisionExit2D.html (For 2D Mode)
+ *
+ * - https://docs.unity3d.com/ScriptReference/MonoBehaviour.OnCollisionExit.html (For 3D Mode) or
+ * - https://docs.unity3d.com/ScriptReference/MonoBehaviour.OnCollisionExit2D.html (For 2D Mode)
  *
  * @param gameObjectIdentifier The identifier for the GameObject that you want to bind the lifecycle event function on.
  * @param eventFunction The lifecycle event function for handling this event.
@@ -886,9 +928,12 @@ export function on_collision_exit(gameObjectIdentifier : GameObjectIdentifier, e
 
 
 /**
- * Draw a text (string) on the screen with given <b>screen space position</b> in the current frame.<br>
- * The origin of screen space is upper-left corner and the positive Y direction is downward.<br>
- * The drawn text will only last for one frame. You should put this under the `Update` function (or a function that is called by the `Update` function) to keep the text stays in every frame.<br>
+ * Draw a text (string) on the screen with given **screen space position** in the current frame.
+ *
+ * The origin of screen space is upper-left corner and the positive Y direction is downward.
+ *
+ * The drawn text will only last for one frame. You should put this under the `Update` function (or a function that is called by the `Update` function) to keep the text stays in every frame.
+ *
  *
  * @param content The string you want to display on screen.
  * @param x The x coordinate of the text (in screen position).
@@ -908,14 +953,18 @@ export function gui_label(content : string, x : number, y : number, fontSize : n
 
 
 /**
- * Make a button on the screen with given <b>screen space position</b> in the current frame. When user clicks the button, the `onClick` function will be called.<br>
- * The origin of screen space is upper-left corner and the positive Y direction is downward.<br>
+ * Make a button on the screen with given **screen space position** in the current frame. When user clicks the button, the `onClick` function will be called.
+ *
+ * The origin of screen space is upper-left corner and the positive Y direction is downward.
+ *
  * The drawn button will only last for one frame. You should put this under the `Update` function (or a function that is called by the `Update` function) to keep the button stays in every frame.
- * <br>
- * <br>
- * If this function is called by a lifecycle event function, then the `onClick` function in the fourth parameter could also be considered as a lifecycle event function.<br>
- * This means that you can use other functions from this module inside the `onClick` function, even though the functions are not under the `Outside Lifecycle` category.<br>
+ *
+ * If this function is called by a lifecycle event function, then the `onClick` function in the fourth parameter could also be considered as a lifecycle event function.
+ *
+ * This means that you can use other functions from this module inside the `onClick` function, even though the functions are not under the `Outside Lifecycle` category.
+ *
  * For example, the code piece below
+ *
  * ```
  * import {init_unity_academy_3d, set_start, set_update, instantiate, gui_button, set_position }
  * from "unity_academy";
@@ -931,7 +980,8 @@ export function gui_label(content : string, x : number, y : number, fontSize : n
 
  * set_update(cube, cube_update);
  * ```
- * is correct.<br>
+ *
+ * is correct.
  *
  * @param text The text you want to display on the button.
  * @param x The x coordinate of the button (in screen position).
@@ -952,12 +1002,15 @@ export function gui_button(text : string, x: number, y : number, fontSize : numb
 }
 
 /**
- * Get the main camera following target GameObject (an invisible GameObject) to use it to control the position of the main camera with the default camera controller.<br><br>
- * <b>In 3D mode</b>, the default camera controller behaves as third-person camera controller, and the center to follow is the following target GameObject. Also, Unity Academy will automatically set the rotation of this "following target" to the same rotation as the current main camera's rotation to let you get the main camera's rotation.<br>
- * <b>In 2D mode</b>, the default camera controller will follow the target GameObject to move, along with a position delta value that you can adjust with the arrow keys on your keyboard.<br><br>
- * The main camera following target GameObject is a primitive GameObject. This means that you are not allowed to destroy it and/or instantiate it during runtime. Multiple calls to this function will return GameObject identifiers that refer to the same primitive GameObject.<br>
- * <br>
- * <br><b>If default main camera controllers are disabled (you have called `request_for_main_camera_control`), then the following target GameObject is useless.</b>
+ * Get the main camera following target GameObject (an invisible GameObject) to use it to control the position of the main camera with the default camera controller.
+ *
+ * **In 3D mode**, the default camera controller behaves as third-person camera controller, and the center to follow is the following target GameObject. Also, Unity Academy will automatically set the rotation of this "following target" to the same rotation as the current main camera's rotation to let you get the main camera's rotation.
+ *
+ * **In 2D mode**, the default camera controller will follow the target GameObject to move, along with a position delta value that you can adjust with the arrow keys on your keyboard.
+ *
+ * The main camera following target GameObject is a primitive GameObject. This means that you are not allowed to destroy it and/or instantiate it during runtime. Multiple calls to this function will return GameObject identifiers that refer to the same primitive GameObject.
+ *
+ * **If default main camera controllers are disabled (you have called `request_for_main_camera_control`), then the following target GameObject is useless.**
  *
  * @return The GameObject idenfitier for the main camera following target GameObject.
  * @category Camera
@@ -971,11 +1024,12 @@ export function get_main_camera_following_target() : GameObjectIdentifier {
 
 
 /**
- * Request for main camera control and get a GameObject identifier that can directly be used to control the main camera's position and rotation.<br>
- * <br>
- * When you request for the direct control over main camera with this function, the default camera controllers will be disabled, thus the GameObject identifier returned by `get_main_camera_following_target` will become useless, as you can no longer use the default main camera controllers.<br>
- * <br>
- * This function is for totally customizing the position and rotation of the main camera. If you'd like to simplify the camera controlling with the help of the default camera controllers in Unity Academy, please consider use `get_main_camera_following_target` function.<br>
+ * Request for main camera control and get a GameObject identifier that can directly be used to control the main camera's position and rotation.
+ *
+ * When you request for the direct control over main camera with this function, the default camera controllers will be disabled, thus the GameObject identifier returned by `get_main_camera_following_target` will become useless, as you can no longer use the default main camera controllers.
+ *
+ * This function is for totally customizing the position and rotation of the main camera. If you'd like to simplify the camera controlling with the help of the default camera controllers in Unity Academy, please consider use `get_main_camera_following_target` function.
+ *
  *
  * @return The GameObject identifier that can directly be used to control the main camera's position and rotation
  * @category Camera

--- a/src/bundles/unity_academy/index.ts
+++ b/src/bundles/unity_academy/index.ts
@@ -1,15 +1,14 @@
 /**
  * <b>A module that allows students to program with Unity Engine in either <u>2-D</u> or <u>3-D</u> scene in Source Academy.</b>
- * <br>
+ *
  * Makes use of "<b>Unity Academy Embedded WebGL Frontend</b>" (also made by me) to work together.<br>
- * <br>
+ *
  * <b>Code Examples: </b><a href = 'https://unity-academy.s3.ap-southeast-1.amazonaws.com/code_examples.html' rel="noopener noreferrer" target="_blank">Click Here</a><br>
  * <b>Prefab Information: </b><a href = 'https://unity-academy.s3.ap-southeast-1.amazonaws.com/webgl_assetbundles/prefab_info.html' rel="noopener noreferrer" target="_blank">Click Here</a><br>
  * <b>User Agreement: </b><a href = 'https://unity-academy.s3.ap-southeast-1.amazonaws.com/user_agreement.html' rel="noopener noreferrer" target="_blank">Click Here</a><br>
- * <br>
+ *
  * <b><u>Note that you need to use this module with a '<i>Native</i>' variant of Source language, otherwise you may get strange errors.</u></b>
- * <br>
- * <br>
+ *
  * <b>Lifecycle Event Functions</b><br>
  * ● Unity Academy has its own internal loop on students' GameObject lifecycle.<br>
  * ● <u>Lifecycle event functions</u> are functions that are not supposed to be called by Source Academy's default evaluator, instead they are called by Unity Academy at certain time in the GameObject's lifecycle.<br>
@@ -41,26 +40,23 @@
  * }
  * set_start(cube, my_start); // Correct
  * ```
- * <br>
+ *
  * When any runtime errors happen in lifecycle event functions, they will be displayed in Unity Academy's information page and the lifecycle event function that caused the errors will automatically unbind from the GameObject.
- * <br>
- * <br>
+ *
  * <b>Input Function Key Codes</b> Accepts A-Z, a-z and "LeftMouseBtn" / "RightMouseBtn" / "MiddleMouseBtn" / "LeftShift" / "RightShift"
- * <br>
- * <br>
+ *
  * <b>Key differences between 2D and 3D mode</b><br>
  * ● <u>In 2D mode</u> the main camera renders the scene in <b>orthographic</b> mode (Z position is used to determine sequence when sprites overlapping), whereas <u>in 3D mode</u> the camera renders the scene in <b>perspective</b> mode. Moreover, 3D mode and 2D mode have different kinds of default camera controller.<br>
  * ● <u>In 2D mode</u>, due to the loss of one dimension, for some values and axis in 3D coordinate system, they sometimes behaves differently with 3D mode. For example, some coordinate values is ignored in 2D mode. Whereas <u>in 3D mode</u> you can use the fully-supported 3D coordinate system. (Actually, in general, Unity Academy just simply uses 3D space and an orthographic camera to simulate 2D space.)<br>
  * ● <u>In 2D mode</u> you need to use <b>instantiate_sprite</b> to create new GameObjects, whereas <u>in 3D mode</u> you need to use <b>instantiate</b> to create new GameObjects.<br>
  * ● <u>In 2D mode</u> Unity Academy will use Rigidbody2D and 2D colliders like BoxCollider2D for physics engine (certain values for 3D physics engine in 2D physics engine is ignored and will always be zero), whereas <u>in 3D mode</u> Unity Academy use regular 3D rigidbody and 3D colliders to simulate 3D physics.<br>
  * ● <u>In 2D mode</u> playing frame animations for sprite GameObjects is currently unavailable, whereas <u>in 3D mode</u> you need to use <b>play_animator_state</b> to play 3D animations.<br>
- * <br>
- * <br>
+ *
+ *
  * <b>Space and Coordinates</b><br>
  * ● <u>3D:</u> Uses <b>left-hand coordinate system</b>: +X denotes rightward, +Y denotes upward, +Z denotes forward.<br>
  * ● <u>2D:</u> +X denotes rightward, +Y denotes upward, Z value actually still exists and usually used for determining sequence of overlapping 2D GameObjects like sprites.
- * <br>
- * <br>
+ *
  * <b>Unity Academy Camera Control (only available when the default camera controllers are being used)</b><br>
  * ● <u>In 2D mode:</u><br>
  * ● 'W'/'A'/'S'/'D' : Moves the main camera around<br>

--- a/src/bundles/unity_academy/index.ts
+++ b/src/bundles/unity_academy/index.ts
@@ -1,7 +1,7 @@
 /**
  * **A module that allows students to program with Unity Engine in either <u>2-D</u> or <u>3-D</u> scene in Source Academy.**
  *
- * Makes use of "**Unity Academy Embedded WebGL Frontend**" (also made by me) to work together.<br>
+ * Makes use of "**Unity Academy Embedded WebGL Frontend**" (also made by me) to work together.
  *
  * **Code Examples:** <a href = 'https://unity-academy.s3.ap-southeast-1.amazonaws.com/code_examples.html' rel="noopener noreferrer" target="_blank">Click Here</a><br>
  * **Prefab Information:** <a href = 'https://unity-academy.s3.ap-southeast-1.amazonaws.com/webgl_assetbundles/prefab_info.html' rel="noopener noreferrer" target="_blank">Click Here</a><br>
@@ -9,23 +9,30 @@
  *
  * **<u>Note that you need to use this module with a '<i>Native</i>' variant of Source language, otherwise you may get strange errors.</u>**
  *
- * **Lifecycle Event Functions**<br>
- * - Unity Academy has its own internal loop on students' GameObject lifecycle.<br>
- * - <u>Lifecycle event functions</u> are functions that are not supposed to be called by Source Academy's default evaluator, instead they are called by Unity Academy at certain time in the GameObject's lifecycle.<br>
- * - Currently there are five types of Unity Academy lifecycle event function: `Start`, `Update` and three collision detaction functions.<br>
- * - Both `Start` and `Update` functions should be a student-side function object with only one parameter, which automatically refers to the GameObject that is binded with the function when Unity Academy calls the function. So different GameObject instances can share the same lifecycle event function together.<br>
+ * **Lifecycle Event Functions**
+ *
+ * - Unity Academy has its own internal loop on students' GameObject lifecycle.
+ * - <u>Lifecycle event functions</u> are functions that are not supposed to be called by Source Academy's default evaluator, instead they are called by Unity Academy at certain time in the GameObject's lifecycle.
+ * - Currently there are five types of Unity Academy lifecycle event function: `Start`, `Update` and three collision detaction functions.
+ * - Both `Start` and `Update` functions should be a student-side function object with only one parameter, which automatically refers to the GameObject that is binded with the function when Unity Academy calls the function. So different GameObject instances can share the same lifecycle event function together.
+ *
  * For example:
+ *
  * ```
  * function my_start(gameObject){...};
  * const my_update = (gameObject) => {...};
  * ```
- * - The functions `set_start` and `set_update` in this module can be used to set one GameObject's `Start` and `Update` functions<br>
- * - ===>`Start` is called only for one time after the GameObject is created (instantiated) and before its first `Update` call.<br>
- * - ===>`Update` is called on every GameObject once in every frame after `Start` have been called. <br>
- * - For the three collision detaction lifecycle event functions, please refer to `on_collision_enter`, `on_collision_stay` and `on_collision_exit` functions under the `Physics - Collision` category.<br>
- * - You can not bind multiple lifecycle functions of the same type to the same GameObject. For example, you can't bind two `Update` functions to the same GameObject. In this case, previously binded `Update` functions will be overwritten by the latest binded `Update` function.<br><br>
- * <u>**[IMPORTANT]** All functions in this module that is NOT under the "**Outside Lifecycle**" or "Maths" category need to call by Unity Academy lifecycle event functions (directly or intermediately) to work correctly. Failure to follow this rule may lead to noneffective or incorrect behaviors of the functions and may crash the Unity Academy instance.</u><br>
+ *
+ * - The functions `set_start` and `set_update` in this module can be used to set one GameObject's `Start` and `Update` functions
+ *   - `Start` is called only for one time after the GameObject is created (instantiated) and before its first `Update` call.
+ *   - `Update` is called on every GameObject once in every frame after `Start` have been called.
+ * - For the three collision detaction lifecycle event functions, please refer to `on_collision_enter`, `on_collision_stay` and `on_collision_exit` functions under the `Physics - Collision` category.
+ * - You can not bind multiple lifecycle functions of the same type to the same GameObject. For example, you can't bind two `Update` functions to the same GameObject. In this case, previously binded `Update` functions will be overwritten by the latest binded `Update` function.
+ *
+ * <u>**[IMPORTANT]** All functions in this module that is NOT under the "**Outside Lifecycle**" or "Maths" category need to call by Unity Academy lifecycle event functions (directly or intermediately) to work correctly. Failure to follow this rule may lead to noneffective or incorrect behaviors of the functions and may crash the Unity Academy instance.</u>
+ *
  * For example:
+ *
  * ```
  * import {init_unity_academy_3d, instantiate, set_start, set_update, set_position, set_rotation_euler} from 'unity_academy';
  * init_unity_academy_3d(); // Correct, since this function is under the "Outside Lifecycle" category and it can be called outside lifecycle event functions.
@@ -45,26 +52,28 @@
  *
  * **Input Function Key Codes** Accepts A-Z, a-z and "LeftMouseBtn" / "RightMouseBtn" / "MiddleMouseBtn" / "LeftShift" / "RightShift"
  *
- * **Key differences between 2D and 3D mode**<br>
- * - <u>In 2D mode</u> the main camera renders the scene in **orthographic** mode (Z position is used to determine sequence when sprites overlapping), whereas <u>in 3D mode</u> the camera renders the scene in **perspective** mode. Moreover, 3D mode and 2D mode have different kinds of default camera controller.<br>
- * - <u>In 2D mode</u>, due to the loss of one dimension, for some values and axis in 3D coordinate system, they sometimes behaves differently with 3D mode. For example, some coordinate values is ignored in 2D mode. Whereas <u>in 3D mode</u> you can use the fully-supported 3D coordinate system. (Actually, in general, Unity Academy just simply uses 3D space and an orthographic camera to simulate 2D space.)<br>
- * - <u>In 2D mode</u> you need to use **instantiate_sprite** to create new GameObjects, whereas <u>in 3D mode</u> you need to use **instantiate** to create new GameObjects.<br>
- * - <u>In 2D mode</u> Unity Academy will use Rigidbody2D and 2D colliders like BoxCollider2D for physics engine (certain values for 3D physics engine in 2D physics engine is ignored and will always be zero), whereas <u>in 3D mode</u> Unity Academy use regular 3D rigidbody and 3D colliders to simulate 3D physics.<br>
- * - <u>In 2D mode</u> playing frame animations for sprite GameObjects is currently unavailable, whereas <u>in 3D mode</u> you need to use **play_animator_state** to play 3D animations.<br>
+ * **Key differences between 2D and 3D mode**
  *
+ * - <u>In 2D mode</u> the main camera renders the scene in **orthographic** mode (Z position is used to determine sequence when sprites overlapping), whereas <u>in 3D mode</u> the camera renders the scene in **perspective** mode. Moreover, 3D mode and 2D mode have different kinds of default camera controller.
+ * - <u>In 2D mode</u>, due to the loss of one dimension, for some values and axis in 3D coordinate system, they sometimes behaves differently with 3D mode. For example, some coordinate values is ignored in 2D mode. Whereas <u>in 3D mode</u> you can use the fully-supported 3D coordinate system. (Actually, in general, Unity Academy just simply uses 3D space and an orthographic camera to simulate 2D space.)
+ * - <u>In 2D mode</u> you need to use **instantiate_sprite** to create new GameObjects, whereas <u>in 3D mode</u> you need to use **instantiate** to create new GameObjects.
+ * - <u>In 2D mode</u> Unity Academy will use Rigidbody2D and 2D colliders like BoxCollider2D for physics engine (certain values for 3D physics engine in 2D physics engine is ignored and will always be zero), whereas <u>in 3D mode</u> Unity Academy use regular 3D rigidbody and 3D colliders to simulate 3D physics.
+ * - <u>In 2D mode</u> playing frame animations for sprite GameObjects is currently unavailable, whereas <u>in 3D mode</u> you need to use **play_animator_state** to play 3D animations.
  *
- * **Space and Coordinates**<br>
- * - <u>3D:</u> Uses **left-hand coordinate system**: +X denotes rightward, +Y denotes upward, +Z denotes forward.<br>
+ * **Space and Coordinates**
+ *
+ * - <u>3D:</u> Uses **left-hand coordinate system**: +X denotes rightward, +Y denotes upward, +Z denotes forward.
  * - <u>2D:</u> +X denotes rightward, +Y denotes upward, Z value actually still exists and usually used for determining sequence of overlapping 2D GameObjects like sprites.
  *
- * **Unity Academy Camera Control (only available when the default camera controllers are being used)**<br>
- * - <u>In 2D mode:</u><br>
- * - 'W'/'A'/'S'/'D' : Moves the main camera around<br>
- * - '=' (equals key) : Resets the main camera to its initial position<br>
- * - <u>In 3D mode:</u><br>
- * - '=' (equals key) : Resets the main camera to its initial position and rotation<br>
- * - Left Mouse Button : Hold to rotate the main camera in a faster speed<br>
- * - Mouse Scrollwheel : Zoom in / out
+ * **Unity Academy Camera Control (only available when the default camera controllers are being used)**
+ *
+ * - <u>In 2D mode:</u>
+ *   - 'W'/'A'/'S'/'D' : Moves the main camera around
+ *   - '=' (equals key) : Resets the main camera to its initial position
+ * - <u>In 3D mode:</u>
+ *   - '=' (equals key) : Resets the main camera to its initial position and rotation
+ *   - Left Mouse Button : Hold to rotate the main camera in a faster speed
+ *   - Mouse Scrollwheel : Zoom in / out
  * @module unity_academy
  * @author Wang Zihan
  */

--- a/src/bundles/unity_academy/index.ts
+++ b/src/bundles/unity_academy/index.ts
@@ -10,20 +10,20 @@
  * <b><u>Note that you need to use this module with a '<i>Native</i>' variant of Source language, otherwise you may get strange errors.</u></b>
  *
  * <b>Lifecycle Event Functions</b><br>
- * ● Unity Academy has its own internal loop on students' GameObject lifecycle.<br>
- * ● <u>Lifecycle event functions</u> are functions that are not supposed to be called by Source Academy's default evaluator, instead they are called by Unity Academy at certain time in the GameObject's lifecycle.<br>
- * ● Currently there are five types of Unity Academy lifecycle event function: `Start`, `Update` and three collision detaction functions.<br>
- * ● Both `Start` and `Update` functions should be a student-side function object with only one parameter, which automatically refers to the GameObject that is binded with the function when Unity Academy calls the function. So different GameObject instances can share the same lifecycle event function together.<br>
+ * - Unity Academy has its own internal loop on students' GameObject lifecycle.<br>
+ * - <u>Lifecycle event functions</u> are functions that are not supposed to be called by Source Academy's default evaluator, instead they are called by Unity Academy at certain time in the GameObject's lifecycle.<br>
+ * - Currently there are five types of Unity Academy lifecycle event function: `Start`, `Update` and three collision detaction functions.<br>
+ * - Both `Start` and `Update` functions should be a student-side function object with only one parameter, which automatically refers to the GameObject that is binded with the function when Unity Academy calls the function. So different GameObject instances can share the same lifecycle event function together.<br>
  * For example:
  * ```
  * function my_start(gameObject){...};
  * const my_update = (gameObject) => {...};
  * ```
- * ● The functions `set_start` and `set_update` in this module can be used to set one GameObject's `Start` and `Update` functions<br>
- * ● ===>`Start` is called only for one time after the GameObject is created (instantiated) and before its first `Update` call.<br>
- * ● ===>`Update` is called on every GameObject once in every frame after `Start` have been called. <br>
- * ● For the three collision detaction lifecycle event functions, please refer to `on_collision_enter`, `on_collision_stay` and `on_collision_exit` functions under the `Physics - Collision` category.<br>
- * ● You can not bind multiple lifecycle functions of the same type to the same GameObject. For example, you can't bind two `Update` functions to the same GameObject. In this case, previously binded `Update` functions will be overwritten by the latest binded `Update` function.<br><br>
+ * - The functions `set_start` and `set_update` in this module can be used to set one GameObject's `Start` and `Update` functions<br>
+ * - ===>`Start` is called only for one time after the GameObject is created (instantiated) and before its first `Update` call.<br>
+ * - ===>`Update` is called on every GameObject once in every frame after `Start` have been called. <br>
+ * - For the three collision detaction lifecycle event functions, please refer to `on_collision_enter`, `on_collision_stay` and `on_collision_exit` functions under the `Physics - Collision` category.<br>
+ * - You can not bind multiple lifecycle functions of the same type to the same GameObject. For example, you can't bind two `Update` functions to the same GameObject. In this case, previously binded `Update` functions will be overwritten by the latest binded `Update` function.<br><br>
  * <u><b>[IMPORTANT]</b> All functions in this module that is NOT under the "<b>Outside Lifecycle</b>" or "Maths" category need to call by Unity Academy lifecycle event functions (directly or intermediately) to work correctly. Failure to follow this rule may lead to noneffective or incorrect behaviors of the functions and may crash the Unity Academy instance.</u><br>
  * For example:
  * ```
@@ -46,25 +46,25 @@
  * <b>Input Function Key Codes</b> Accepts A-Z, a-z and "LeftMouseBtn" / "RightMouseBtn" / "MiddleMouseBtn" / "LeftShift" / "RightShift"
  *
  * <b>Key differences between 2D and 3D mode</b><br>
- * ● <u>In 2D mode</u> the main camera renders the scene in <b>orthographic</b> mode (Z position is used to determine sequence when sprites overlapping), whereas <u>in 3D mode</u> the camera renders the scene in <b>perspective</b> mode. Moreover, 3D mode and 2D mode have different kinds of default camera controller.<br>
- * ● <u>In 2D mode</u>, due to the loss of one dimension, for some values and axis in 3D coordinate system, they sometimes behaves differently with 3D mode. For example, some coordinate values is ignored in 2D mode. Whereas <u>in 3D mode</u> you can use the fully-supported 3D coordinate system. (Actually, in general, Unity Academy just simply uses 3D space and an orthographic camera to simulate 2D space.)<br>
- * ● <u>In 2D mode</u> you need to use <b>instantiate_sprite</b> to create new GameObjects, whereas <u>in 3D mode</u> you need to use <b>instantiate</b> to create new GameObjects.<br>
- * ● <u>In 2D mode</u> Unity Academy will use Rigidbody2D and 2D colliders like BoxCollider2D for physics engine (certain values for 3D physics engine in 2D physics engine is ignored and will always be zero), whereas <u>in 3D mode</u> Unity Academy use regular 3D rigidbody and 3D colliders to simulate 3D physics.<br>
- * ● <u>In 2D mode</u> playing frame animations for sprite GameObjects is currently unavailable, whereas <u>in 3D mode</u> you need to use <b>play_animator_state</b> to play 3D animations.<br>
+ * - <u>In 2D mode</u> the main camera renders the scene in <b>orthographic</b> mode (Z position is used to determine sequence when sprites overlapping), whereas <u>in 3D mode</u> the camera renders the scene in <b>perspective</b> mode. Moreover, 3D mode and 2D mode have different kinds of default camera controller.<br>
+ * - <u>In 2D mode</u>, due to the loss of one dimension, for some values and axis in 3D coordinate system, they sometimes behaves differently with 3D mode. For example, some coordinate values is ignored in 2D mode. Whereas <u>in 3D mode</u> you can use the fully-supported 3D coordinate system. (Actually, in general, Unity Academy just simply uses 3D space and an orthographic camera to simulate 2D space.)<br>
+ * - <u>In 2D mode</u> you need to use <b>instantiate_sprite</b> to create new GameObjects, whereas <u>in 3D mode</u> you need to use <b>instantiate</b> to create new GameObjects.<br>
+ * - <u>In 2D mode</u> Unity Academy will use Rigidbody2D and 2D colliders like BoxCollider2D for physics engine (certain values for 3D physics engine in 2D physics engine is ignored and will always be zero), whereas <u>in 3D mode</u> Unity Academy use regular 3D rigidbody and 3D colliders to simulate 3D physics.<br>
+ * - <u>In 2D mode</u> playing frame animations for sprite GameObjects is currently unavailable, whereas <u>in 3D mode</u> you need to use <b>play_animator_state</b> to play 3D animations.<br>
  *
  *
  * <b>Space and Coordinates</b><br>
- * ● <u>3D:</u> Uses <b>left-hand coordinate system</b>: +X denotes rightward, +Y denotes upward, +Z denotes forward.<br>
- * ● <u>2D:</u> +X denotes rightward, +Y denotes upward, Z value actually still exists and usually used for determining sequence of overlapping 2D GameObjects like sprites.
+ * - <u>3D:</u> Uses <b>left-hand coordinate system</b>: +X denotes rightward, +Y denotes upward, +Z denotes forward.<br>
+ * - <u>2D:</u> +X denotes rightward, +Y denotes upward, Z value actually still exists and usually used for determining sequence of overlapping 2D GameObjects like sprites.
  *
  * <b>Unity Academy Camera Control (only available when the default camera controllers are being used)</b><br>
- * ● <u>In 2D mode:</u><br>
- * ● 'W'/'A'/'S'/'D' : Moves the main camera around<br>
- * ● '=' (equals key) : Resets the main camera to its initial position<br>
- * ● <u>In 3D mode:</u><br>
- * ● '=' (equals key) : Resets the main camera to its initial position and rotation<br>
- * ● Left Mouse Button : Hold to rotate the main camera in a faster speed<br>
- * ● Mouse Scrollwheel : Zoom in / out
+ * - <u>In 2D mode:</u><br>
+ * - 'W'/'A'/'S'/'D' : Moves the main camera around<br>
+ * - '=' (equals key) : Resets the main camera to its initial position<br>
+ * - <u>In 3D mode:</u><br>
+ * - '=' (equals key) : Resets the main camera to its initial position and rotation<br>
+ * - Left Mouse Button : Hold to rotate the main camera in a faster speed<br>
+ * - Mouse Scrollwheel : Zoom in / out
  * @module unity_academy
  * @author Wang Zihan
  */

--- a/src/bundles/unity_academy/index.ts
+++ b/src/bundles/unity_academy/index.ts
@@ -1,15 +1,15 @@
 /**
- * <b>A module that allows students to program with Unity Engine in either <u>2-D</u> or <u>3-D</u> scene in Source Academy.</b>
+ * **A module that allows students to program with Unity Engine in either <u>2-D</u> or <u>3-D</u> scene in Source Academy.**
  *
- * Makes use of "<b>Unity Academy Embedded WebGL Frontend</b>" (also made by me) to work together.<br>
+ * Makes use of "**Unity Academy Embedded WebGL Frontend**" (also made by me) to work together.<br>
  *
- * <b>Code Examples: </b><a href = 'https://unity-academy.s3.ap-southeast-1.amazonaws.com/code_examples.html' rel="noopener noreferrer" target="_blank">Click Here</a><br>
- * <b>Prefab Information: </b><a href = 'https://unity-academy.s3.ap-southeast-1.amazonaws.com/webgl_assetbundles/prefab_info.html' rel="noopener noreferrer" target="_blank">Click Here</a><br>
- * <b>User Agreement: </b><a href = 'https://unity-academy.s3.ap-southeast-1.amazonaws.com/user_agreement.html' rel="noopener noreferrer" target="_blank">Click Here</a><br>
+ * **Code Examples:** <a href = 'https://unity-academy.s3.ap-southeast-1.amazonaws.com/code_examples.html' rel="noopener noreferrer" target="_blank">Click Here</a><br>
+ * **Prefab Information:** <a href = 'https://unity-academy.s3.ap-southeast-1.amazonaws.com/webgl_assetbundles/prefab_info.html' rel="noopener noreferrer" target="_blank">Click Here</a><br>
+ * **User Agreement:** <a href = 'https://unity-academy.s3.ap-southeast-1.amazonaws.com/user_agreement.html' rel="noopener noreferrer" target="_blank">Click Here</a><br>
  *
- * <b><u>Note that you need to use this module with a '<i>Native</i>' variant of Source language, otherwise you may get strange errors.</u></b>
+ * **<u>Note that you need to use this module with a '<i>Native</i>' variant of Source language, otherwise you may get strange errors.</u>**
  *
- * <b>Lifecycle Event Functions</b><br>
+ * **Lifecycle Event Functions**<br>
  * - Unity Academy has its own internal loop on students' GameObject lifecycle.<br>
  * - <u>Lifecycle event functions</u> are functions that are not supposed to be called by Source Academy's default evaluator, instead they are called by Unity Academy at certain time in the GameObject's lifecycle.<br>
  * - Currently there are five types of Unity Academy lifecycle event function: `Start`, `Update` and three collision detaction functions.<br>
@@ -24,7 +24,7 @@
  * - ===>`Update` is called on every GameObject once in every frame after `Start` have been called. <br>
  * - For the three collision detaction lifecycle event functions, please refer to `on_collision_enter`, `on_collision_stay` and `on_collision_exit` functions under the `Physics - Collision` category.<br>
  * - You can not bind multiple lifecycle functions of the same type to the same GameObject. For example, you can't bind two `Update` functions to the same GameObject. In this case, previously binded `Update` functions will be overwritten by the latest binded `Update` function.<br><br>
- * <u><b>[IMPORTANT]</b> All functions in this module that is NOT under the "<b>Outside Lifecycle</b>" or "Maths" category need to call by Unity Academy lifecycle event functions (directly or intermediately) to work correctly. Failure to follow this rule may lead to noneffective or incorrect behaviors of the functions and may crash the Unity Academy instance.</u><br>
+ * <u>**[IMPORTANT]** All functions in this module that is NOT under the "**Outside Lifecycle**" or "Maths" category need to call by Unity Academy lifecycle event functions (directly or intermediately) to work correctly. Failure to follow this rule may lead to noneffective or incorrect behaviors of the functions and may crash the Unity Academy instance.</u><br>
  * For example:
  * ```
  * import {init_unity_academy_3d, instantiate, set_start, set_update, set_position, set_rotation_euler} from 'unity_academy';
@@ -43,21 +43,21 @@
  *
  * When any runtime errors happen in lifecycle event functions, they will be displayed in Unity Academy's information page and the lifecycle event function that caused the errors will automatically unbind from the GameObject.
  *
- * <b>Input Function Key Codes</b> Accepts A-Z, a-z and "LeftMouseBtn" / "RightMouseBtn" / "MiddleMouseBtn" / "LeftShift" / "RightShift"
+ * **Input Function Key Codes** Accepts A-Z, a-z and "LeftMouseBtn" / "RightMouseBtn" / "MiddleMouseBtn" / "LeftShift" / "RightShift"
  *
- * <b>Key differences between 2D and 3D mode</b><br>
- * - <u>In 2D mode</u> the main camera renders the scene in <b>orthographic</b> mode (Z position is used to determine sequence when sprites overlapping), whereas <u>in 3D mode</u> the camera renders the scene in <b>perspective</b> mode. Moreover, 3D mode and 2D mode have different kinds of default camera controller.<br>
+ * **Key differences between 2D and 3D mode**<br>
+ * - <u>In 2D mode</u> the main camera renders the scene in **orthographic** mode (Z position is used to determine sequence when sprites overlapping), whereas <u>in 3D mode</u> the camera renders the scene in **perspective** mode. Moreover, 3D mode and 2D mode have different kinds of default camera controller.<br>
  * - <u>In 2D mode</u>, due to the loss of one dimension, for some values and axis in 3D coordinate system, they sometimes behaves differently with 3D mode. For example, some coordinate values is ignored in 2D mode. Whereas <u>in 3D mode</u> you can use the fully-supported 3D coordinate system. (Actually, in general, Unity Academy just simply uses 3D space and an orthographic camera to simulate 2D space.)<br>
- * - <u>In 2D mode</u> you need to use <b>instantiate_sprite</b> to create new GameObjects, whereas <u>in 3D mode</u> you need to use <b>instantiate</b> to create new GameObjects.<br>
+ * - <u>In 2D mode</u> you need to use **instantiate_sprite** to create new GameObjects, whereas <u>in 3D mode</u> you need to use **instantiate** to create new GameObjects.<br>
  * - <u>In 2D mode</u> Unity Academy will use Rigidbody2D and 2D colliders like BoxCollider2D for physics engine (certain values for 3D physics engine in 2D physics engine is ignored and will always be zero), whereas <u>in 3D mode</u> Unity Academy use regular 3D rigidbody and 3D colliders to simulate 3D physics.<br>
- * - <u>In 2D mode</u> playing frame animations for sprite GameObjects is currently unavailable, whereas <u>in 3D mode</u> you need to use <b>play_animator_state</b> to play 3D animations.<br>
+ * - <u>In 2D mode</u> playing frame animations for sprite GameObjects is currently unavailable, whereas <u>in 3D mode</u> you need to use **play_animator_state** to play 3D animations.<br>
  *
  *
- * <b>Space and Coordinates</b><br>
- * - <u>3D:</u> Uses <b>left-hand coordinate system</b>: +X denotes rightward, +Y denotes upward, +Z denotes forward.<br>
+ * **Space and Coordinates**<br>
+ * - <u>3D:</u> Uses **left-hand coordinate system**: +X denotes rightward, +Y denotes upward, +Z denotes forward.<br>
  * - <u>2D:</u> +X denotes rightward, +Y denotes upward, Z value actually still exists and usually used for determining sequence of overlapping 2D GameObjects like sprites.
  *
- * <b>Unity Academy Camera Control (only available when the default camera controllers are being used)</b><br>
+ * **Unity Academy Camera Control (only available when the default camera controllers are being used)**<br>
  * - <u>In 2D mode:</u><br>
  * - 'W'/'A'/'S'/'D' : Moves the main camera around<br>
  * - '=' (equals key) : Resets the main camera to its initial position<br>


### PR DESCRIPTION
# Description

> We support markdown for documentation, so we should write our documentation in markdown, not HTML.

Fixes formatting of documentation (especially in Unity Academy). Fixes style inconsistencies as well as rendering bugs that are as a result of the HTML being rendered as-is.

This also makes the documentation compatible with our upcoming documentation repository,

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update