### PR TITLE
Improve placement of model in curve3D render tab

### DIFF
--- a/src/tabs/Curve/3Dcurve_anim_canvas.tsx
+++ b/src/tabs/Curve/3Dcurve_anim_canvas.tsx
@@ -306,10 +306,35 @@ State
         <div
           style={{
             display: 'flex',
+            flexDirection: 'column',
             alignContent: 'center',
             justifyContent: 'center',
           }}
         >
+          <div
+            style={{
+              display: 'flex',
+              marginTop: '10px',
+              padding: '10px',
+              flexDirection: 'row',
+              justifyContent: 'stretch',
+              alignContent: 'center',
+            }}
+          >
+            {buttons}
+            {sliders}
+            <Switch
+              style={{
+                marginLeft: '20px',
+                marginRight: '20px',
+                marginTop: '10px',
+                whiteSpace: 'nowrap',
+              }}
+              label="Auto Play"
+              onChange={this.autoPlaySwitchChanged}
+              checked={this.state.autoPlay}
+            />
+          </div>
           <WebGLCanvas
             style={{
               flexGrow: 1,
@@ -317,30 +342,6 @@ State
             ref={(r) => {
               this.canvas = r;
             }}
-          />
-        </div>
-        <div
-          style={{
-            display: 'flex',
-            marginTop: '10px',
-            padding: '10px',
-            flexDirection: 'row',
-            justifyContent: 'stretch',
-            alignContent: 'center',
-          }}
-        >
-          {buttons}
-          {sliders}
-          <Switch
-            style={{
-              marginLeft: '20px',
-              marginRight: '20px',
-              marginTop: '10px',
-              whiteSpace: 'nowrap',
-            }}
-            label="Auto Play"
-            onChange={this.autoPlaySwitchChanged}
-            checked={this.state.autoPlay}
           />
         </div>
       </>


### PR DESCRIPTION
# Description

This PR fixes #218 where the space usage of the model in the curve3D render output tab is not very optimised. I have shifted the design to a more top-bottom style (instead of the current left-right arrangement).

The changes have been tested and checked locally (see screenshot below):
<img width="1274" alt="Updated Design" src="https://github.com/source-academy/modules/assets/26355099/9cacee35-dce5-4487-bce7-10baebbf244d">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Changes have been tested locally, and all tests and lints passed with no additional warnings/errors introduced by the PR.

# Checklist:
(Note: Some of the items are not applicable for this PR)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
