### PR TITLE
Force game functions var args

### DIFF
--- a/src/bundles/game/functions.ts
+++ b/src/bundles/game/functions.ts
@@ -761,6 +761,7 @@ export default function gameFuncs(): { [name: string]: any } {
   Object.entries(functions)
     .forEach(([key, fn]) => {
       finalFunctions[key] = !scene ? nullFn : fn;
+      finalFunctions[key].minArgsNeeded = fn.length;
     });
 
   return finalFunctions;


### PR DESCRIPTION
# Description

Module function var-args has been broken for awhile. Let's add a quick fix by injecting game functions `minArgsNeeded`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Load modules and check that var args are allowed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
