### PR TITLE
fix recording

### DIFF
--- a/src/bundles/sound/functions.ts
+++ b/src/bundles/sound/functions.ts
@@ -127,7 +127,7 @@ const recording_signal_ms = 100;
 const pre_recording_signal_pause_ms = 200;
 
 function play_recording_signal() {
-  play(sine_sound(1200, recording_signal_ms / 1000));
+  play_concurrently(sine_sound(1200, recording_signal_ms / 1000));
 }
 
 // eslint-disable-next-line @typescript-eslint/no-shadow


### PR DESCRIPTION
# Description

`record` and `record_for` were broken since the sound tab was introduced.