### PR TITLE
Remove hardcoded function names in error messages

### DIFF
--- a/src/bundles/sound/functions.ts
+++ b/src/bundles/sound/functions.ts
@@ -340,12 +340,12 @@ export function play_wave(wave: Wave, duration: number): AudioPlayed {
 export function play(sound: Sound): AudioPlayed {
   // Type-check sound
   if (!is_sound(sound)) {
-    throw new Error(`play is expecting sound, but encountered ${sound}`);
+    throw new Error(`${play.name} is expecting sound, but encountered ${sound}`);
     // If a sound is already playing, terminate execution.
   } else if (isPlaying) {
-    throw new Error('play: audio system still playing previous sound');
+    throw new Error(`${play.name}: audio system still playing previous sound`);
   } else if (get_duration(sound) < 0) {
-    throw new Error('play: duration of sound is negative');
+    throw new Error(`${play.name}: duration of sound is negative`);
   } else {
     // Instantiate audio context if it has not been instantiated.
     if (!audioplayer) {
@@ -424,7 +424,7 @@ export function play_concurrently(sound: Sound): void {
   // Type-check sound
   if (!is_sound(sound)) {
     throw new Error(
-      `play_concurrently is expecting sound, but encountered ${sound}`,
+      `${play_concurrently.name} is expecting sound, but encountered ${sound}`,
     );
   } else if (get_duration(sound) <= 0) {
     // Do nothing

--- a/src/bundles/stereo_sound/functions.ts
+++ b/src/bundles/stereo_sound/functions.ts
@@ -375,12 +375,12 @@ export function play_waves(
 export function play(sound: Sound): AudioPlayed {
   // Type-check sound
   if (!is_sound(sound)) {
-    throw new Error(`play is expecting sound, but encountered ${sound}`);
+    throw new Error(`${play.name} is expecting sound, but encountered ${sound}`);
     // If a sound is already playing, terminate execution.
   } else if (isPlaying) {
-    throw new Error('play: audio system still playing previous sound');
+    throw new Error(`${play.name}: audio system still playing previous sound`);
   } else if (get_duration(sound) < 0) {
-    throw new Error('play: duration of sound is negative');
+    throw new Error(`${play.name}: duration of sound is negative`);
   } else {
     // Instantiate audio context if it has not been instantiated.
     if (!audioplayer) {
@@ -484,7 +484,7 @@ export function play_concurrently(sound: Sound): void {
   // Type-check sound
   if (!is_sound(sound)) {
     throw new Error(
-      `play_concurrently is expecting sound, but encountered ${sound}`,
+      `${play_concurrently.name} is expecting sound, but encountered ${sound}`,
     );
   } else if (get_duration(sound) <= 0) {
     // Do nothing


### PR DESCRIPTION
# Description

Removes hardcoding of function names in error messages in `sound` and `stereo_sound` modules. This allows for a single source of truth for the function name and reduces the effort required to refactor anything.

## Type of change

- [x] Code quality improvements

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
