### PR TITLE
bug fix: zero duration sound

### DIFF
--- a/src/bundles/sound/functions.ts
+++ b/src/bundles/sound/functions.ts
@@ -347,6 +347,8 @@ export function play_in_tab(sound: Sound): Sound {
     throw new Error(`${play_in_tab.name}: audio system still playing previous sound`);
   } else if (get_duration(sound) < 0) {
     throw new Error(`${play_in_tab.name}: duration of sound is negative`);
+  } else if (get_duration(sound) === 0) {
+    return sound;
   } else {
     // Instantiate audio context if it has not been instantiated.
     if (!audioplayer) {
@@ -417,6 +419,8 @@ export function play(sound: Sound): Sound {
     );
   } else if (get_duration(sound) < 0) {
     throw new Error(`${play.name}: duration of sound is negative`);
+  } else if (get_duration(sound) === 0) {
+    return sound;
   } else {
     // Instantiate audio context if it has not been instantiated.
     if (!audioplayer) {

--- a/src/bundles/stereo_sound/functions.ts
+++ b/src/bundles/stereo_sound/functions.ts
@@ -382,6 +382,8 @@ export function play_in_tab(sound: Sound): Sound {
     throw new Error(`${play_in_tab.name}: audio system still playing previous sound`);
   } else if (get_duration(sound) < 0) {
     throw new Error(`${play_in_tab.name}: duration of sound is negative`);
+  } else if (get_duration(sound) === 0) {
+    return sound;
   } else {
     // Instantiate audio context if it has not been instantiated.
     if (!audioplayer) {
@@ -478,6 +480,8 @@ export function play(sound: Sound): Sound {
     throw new Error(`${play.name}: audio system still playing previous sound`);
   } else if (get_duration(sound) < 0) {
     throw new Error(`${play.name}: duration of sound is negative`);
+  } else if (get_duration(sound) === 0) {
+    return sound;
   } else {
     // Instantiate audio context if it has not been instantiated.
     if (!audioplayer) {


### PR DESCRIPTION
Fix regression introduced in https://github.com/source-academy/modules/pull/239

Sounds with duration 0 caused error. Now working:

```
import { play, sine_sound } from 'sound';
play(sine_sound(400, 0));
```
and
```
import { play, sine_sound } from 'stereo_sound';
play(sine_sound(400, 0));
```