### PR TITLE
Revert runtime-error regression in zero duration

### DIFF
--- a/src/bundles/sound/functions.ts
+++ b/src/bundles/sound/functions.ts
@@ -277,8 +277,8 @@ export function record_for(duration: number, buffer: number): () => Sound {
  * @example const s = make_sound(t => Math_sin(2 * Math_PI * 440 * t), 5);
  */
 export function make_sound(wave: Wave, duration: number): Sound {
-  if (duration <= 0) {
-    throw new Error('Sound duration must be greater than 0');
+  if (duration < 0) {
+    throw new Error('Sound duration must be greater than or equal to 0');
   }
 
   return pair((t: number) => (t >= duration ? 0 : wave(t)), duration);


### PR DESCRIPTION
# Description

Revert regression that caused make_sound to reject durations of length 0, which affected the consecutively and simultaneously functions

Note: Issue was caused by #234

## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)
