### PR TITLE
Bug fix and changes to REPL module

### DIFF
--- a/src/bundles/repl/functions.ts
+++ b/src/bundles/repl/functions.ts
@@ -11,8 +11,15 @@ import { COLOR_REPL_DISPLAY_DEFAULT } from './config';
 const INSTANCE = new ProgrammableRepl();
 context.moduleContexts.repl.state = INSTANCE;
 /**
- * Setup the programmable REPL with given metacircular evaulator entrance function
- * @param {evalFunc} evalFunc - metacircular evaulator entrance function
+ * Setup the programmable REPL with given evaulator's entrance function
+ *
+ * The function should take one parameter as the code from the module's editor, for example:
+ * ```js
+ * function parse_and_evaluate(code) {
+ *   // ...
+ * }
+ * ```
+ * @param {evalFunc} evalFunc - evaulator entrance function
  *
  * @category Main
  */

--- a/src/bundles/repl/programmable_repl.ts
+++ b/src/bundles/repl/programmable_repl.ts
@@ -59,17 +59,11 @@ export class ProgrammableRepl {
       this.reRenderTab();
       return;
     }
-    if (retVal === undefined) {
-      this.pushOutputString('undefined', COLOR_RUN_CODE_RESULT);
-    } else if (retVal === null) {
-      this.pushOutputString('null', COLOR_RUN_CODE_RESULT);
-    } else {
-      if (typeof (retVal) === 'string') {
-        retVal = `"${retVal}"`;
-      }
-      // Here must use plain text output mode because retVal contains strings from the users.
-      this.pushOutputString(retVal, COLOR_RUN_CODE_RESULT);
+    if (typeof (retVal) === 'string') {
+      retVal = `"${retVal}"`;
     }
+    // Here must use plain text output mode because retVal contains strings from the users.
+    this.pushOutputString(retVal, COLOR_RUN_CODE_RESULT);
     this.reRenderTab();
     developmentLog('RunCode finished');
   }
@@ -81,7 +75,7 @@ export class ProgrammableRepl {
   // Rich text output method allow output strings to have html tags and css styles.
   pushOutputString(content : string, textColor : string, outputMethod : string = 'plaintext') {
     let tmp = {
-      content,
+      content: content === undefined ? 'undefined' : content === null ? 'null' : content,
       color: textColor,
       outputMethod,
     };

--- a/src/bundles/repl/programmable_repl.ts
+++ b/src/bundles/repl/programmable_repl.ts
@@ -249,7 +249,7 @@ export class ProgrammableRepl {
     this.pushOutputString('<span style=\'font-style:italic;\'>Showing my love to my favorite girls through a SA module, is that the so-called "romance of a programmer"?</span>', 'gray', 'richtext');
     this.pushOutputString('❤❤❤❤❤', 'pink');
     this.pushOutputString('<br>', 'white', 'richtext');
-    this.pushOutputString('If you see this, please check whether you have called <span style=\'font-weight:bold;font-style:italic;\'>invoke_repl</span> function with the correct parameter before using the Programmable Repl Tab.', 'yellow', 'richtext');
+    this.pushOutputString('If you see this, please check whether you have called <span style=\'font-weight:bold;font-style:italic;\'>set_evaluator</span> function with the correct parameter before using the Programmable Repl Tab.', 'yellow', 'richtext');
     return 'Easter Egg!';
   }
 }

--- a/src/bundles/repl/programmable_repl.ts
+++ b/src/bundles/repl/programmable_repl.ts
@@ -49,19 +49,26 @@ export class ProgrammableRepl {
         retVal = this.evalFunction(this.userCodeInEditor);
       }
     } catch (exception: any) {
-      console.log(exception);
-      this.pushOutputString(`Line ${exception.location.start.line.toString()}: ${exception.error.message}`, COLOR_ERROR_MESSAGE);
+      developmentLog(exception);
+      // If the exception has a start line of -1 and an undefined error property, then this exception is most likely to be "incorrect number of arguments" caused by incorrect number of parameters in the evaluator entry function provided by students with set_evaluator.
+      if (exception.location.start.line === -1 && exception.error === undefined) {
+        this.pushOutputString('Error: Unable to use your evaluator to run the code. Does your evaluator entry function contain and only contain exactly one parameter?', COLOR_ERROR_MESSAGE);
+      } else {
+        this.pushOutputString(`Line ${exception.location.start.line.toString()}: ${exception.error?.message}`, COLOR_ERROR_MESSAGE);
+      }
       this.reRenderTab();
       return;
     }
     if (retVal === undefined) {
-      this.pushOutputString('Program exited with undefined return value.', COLOR_RUN_CODE_RESULT);
+      this.pushOutputString('undefined', COLOR_RUN_CODE_RESULT);
+    } else if (retVal === null) {
+      this.pushOutputString('null', COLOR_RUN_CODE_RESULT);
     } else {
       if (typeof (retVal) === 'string') {
         retVal = `"${retVal}"`;
       }
       // Here must use plain text output mode because retVal contains strings from the users.
-      this.pushOutputString(`Program exited with return value ${retVal}`, COLOR_RUN_CODE_RESULT);
+      this.pushOutputString(retVal, COLOR_RUN_CODE_RESULT);
     }
     this.reRenderTab();
     developmentLog('RunCode finished');

--- a/src/tabs/Repl/index.tsx
+++ b/src/tabs/Repl/index.tsx
@@ -110,7 +110,10 @@ class ProgrammableReplGUI extends React.Component<Props, State> {
           border: '2px solid #6f8194',
         }}>
           <AceEditor
-            ref={ (e) => { this.editorInstance = e?.editor; this.replInstance.setEditorInstance(e?.editor); }}
+            ref={ (e) => {
+              this.editorInstance = e?.editor;
+              this.replInstance.setEditorInstance(e?.editor);
+            }}
             style= { {
               width: '100%',
               height: `${editorHeight}px`,

--- a/src/tabs/Repl/index.tsx
+++ b/src/tabs/Repl/index.tsx
@@ -32,6 +32,7 @@ const BOX_PADDING_VALUE = 4;
 class ProgrammableReplGUI extends React.Component<Props, State> {
   public replInstance : ProgrammableRepl;
   private editorAreaRect;
+  private editorInstance;
   constructor(data: Props) {
     super(data);
     this.replInstance = data.programmableReplInstance;
@@ -50,6 +51,7 @@ class ProgrammableReplGUI extends React.Component<Props, State> {
       const height = Math.max(e.clientY - this.editorAreaRect.top - BOX_PADDING_VALUE * 2, MINIMUM_EDITOR_HEIGHT);
       this.replInstance.editorHeight = height;
       this.setState({ editorHeight: height });
+      this.editorInstance.resize();
     }
   };
   private onMouseUp = (_e) => {
@@ -108,7 +110,7 @@ class ProgrammableReplGUI extends React.Component<Props, State> {
           border: '2px solid #6f8194',
         }}>
           <AceEditor
-            ref={ (e) => this.replInstance.setEditorInstance(e?.editor)}
+            ref={ (e) => { this.editorInstance = e?.editor; this.replInstance.setEditorInstance(e?.editor); }}
             style= { {
               width: '100%',
               height: `${editorHeight}px`,


### PR DESCRIPTION
 - Removed "Program exited with return value" message as Professor Martin instructed
 - Fix a bug that causes a runtime error to be shown in the browser's console when student provide an evaluator entry function with incorrect parameter count
   - For example: `set_evaluator(()=>undefined);` or `set_evaluator((param1,param2)=>undefined);`
   - Now the REPL will display the error message `Error: Unable to use your evaluator to run the code. Does your evaluator entry function contains and only contains exactly one parameter?` to students if they make this mistake in their code.
- Other minor changes:
   - Removed "metacircular" in documentation since the module is not only limited to metacircular evaluator, but also possibly on CSE machine and any evaluators that use a function with one parameter to accept raw code as entry.
   - In the error message: the function name `invoke_repl` should be `set_evaluator`