### PR TITLE
🐛 fix: incorrect rgb colors

### DIFF
--- a/src/bundles/plotly/curve_functions.ts
+++ b/src/bundles/plotly/curve_functions.ts
@@ -47,7 +47,7 @@ export function z_of(pt: Point): number {
  * ```
  */
 export function r_of(pt: Point): number {
-  return pt.color[0] ?? 0 * 255;
+  return ( pt.color[0] ?? 0 ) * 255;
 }
 
 /**
@@ -62,7 +62,7 @@ export function r_of(pt: Point): number {
  * ```
  */
 export function g_of(pt: Point): number {
-  return pt.color[1] ?? 0 * 255;
+  return ( pt.color[1] ?? 0 ) * 255;
 }
 
 /**
@@ -77,7 +77,7 @@ export function g_of(pt: Point): number {
  * ```
  */
 export function b_of(pt: Point): number {
-  return pt.color[2] ?? 0 * 255;
+  return ( pt.color[2] ?? 0 ) * 255;
 }
 export function generatePlot(
   type: string,


### PR DESCRIPTION
Plotly treats decimal numbers for rgb value weirdly, where if rgb values are (0.9, 0, 0) it uses 0.9 as a percentage to display bright red

Fixes #279 
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

