### PR TITLE
Fix CSG Union Color Loss

### DIFF
--- a/patches/@jscad+modeling+2.9.6.patch
+++ b/patches/@jscad+modeling+2.9.6.patch
@@ -222,7 +222,7 @@ index cf9c591..af1842c 100644
  }
  
 diff --git a/node_modules/@jscad/modeling/src/operations/booleans/unionGeom3Sub.js b/node_modules/@jscad/modeling/src/operations/booleans/unionGeom3Sub.js
-index a4026e3..3dc6158 100644
+index a4026e3..2ac0689 100644
 --- a/node_modules/@jscad/modeling/src/operations/booleans/unionGeom3Sub.js
 +++ b/node_modules/@jscad/modeling/src/operations/booleans/unionGeom3Sub.js
 @@ -14,8 +14,8 @@ const unionSub = (geometry1, geometry2) => {
@@ -236,3 +236,14 @@ index a4026e3..3dc6158 100644
  
    a.clipTo(b, false)
    // b.clipTo(a, true); // ERROR: doesn't work
+@@ -32,8 +32,8 @@ const unionSub = (geometry1, geometry2) => {
+ // Like union, but when we know that the two solids are not intersecting
+ // Do not use if you are not completely sure that the solids do not intersect!
+ const unionForNonIntersecting = (geometry1, geometry2) => {
+-  let newpolygons = geom3.toPolygons(geometry1)
+-  newpolygons = newpolygons.concat(geom3.toPolygons(geometry2))
++  let newpolygons = geom3.toPolygons(geometry1, true)
++  newpolygons = newpolygons.concat(geom3.toPolygons(geometry2, true))
+   return geom3.create(newpolygons)
+ }
+ 


### PR DESCRIPTION
# Description

Fixes #227

As described in the issue, the `union` operation does not preserve the color of one of the solids when they are non-intersecting. Upon inspection of the JSCAD code, I realized that there is a separate function to handle non-intersecting unions, and the `toPolygons` function was not called with the option of preserving the individual colors of a polygon using the boolean parameter `colorizePolygons`. This has been rectified in this PR.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Running the snippet provided in #227 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
