### PR TITLE
[WIP] Callback for repl module evaluator using default_js_slang

### DIFF
--- a/src/bundles/repl/functions.ts
+++ b/src/bundles/repl/functions.ts
@@ -29,10 +29,27 @@ export function set_evaluator(evalFunc: Function) {
     throw new Error(`Wrong parameter type "${typeName}' in function "set_evaluator". It supposed to be a function and it's the entrance function of your metacircular evaulator.`);
   }
   INSTANCE.evalFunction = evalFunc;
+  INSTANCE.resultCallback = undefined;
   return {
     toReplString: () => '<Programmable Repl Initialized>',
   };
 }
+
+/**
+ * Sets evaluator with jslang, then calls callback when results received.
+ * 
+ * @param callback Callback with return value
+ */
+export function set_js_slang_evaluator_with_callback(
+  callback: (_: any) => void,
+) {
+  INSTANCE.evalFunction = default_js_slang;
+  INSTANCE.resultCallback = callback;
+  return {
+    toReplString: () => '<Programmable Repl Initialized>',
+  };
+}
+
 
 
 /**

--- a/src/bundles/repl/index.ts
+++ b/src/bundles/repl/index.ts
@@ -39,6 +39,7 @@
 
 export {
   set_evaluator,
+  set_js_slang_evaluator_with_callback,
   repl_display,
   set_background_image,
   set_font_size,

--- a/src/bundles/repl/programmable_repl.ts
+++ b/src/bundles/repl/programmable_repl.ts
@@ -12,6 +12,7 @@ import { COLOR_RUN_CODE_RESULT, COLOR_ERROR_MESSAGE, DEFAULT_EDITOR_HEIGHT } fro
 
 export class ProgrammableRepl {
   public evalFunction: Function;
+  public resultCallback: ((result: any) => void) | undefined;
   public userCodeInEditor: string;
   public outputStrings: any[];
   private _editorInstance;
@@ -203,6 +204,7 @@ export class ProgrammableRepl {
         if (evalResult.status !== 'error') {
           this.pushOutputString('js-slang program finished with value:', COLOR_RUN_CODE_RESULT);
           // Here must use plain text output mode because evalResult.value contains strings from the users.
+          this.resultCallback?.(evalResult.value);
           this.pushOutputString(evalResult.value === undefined ? 'undefined' : evalResult.value.toString(), COLOR_RUN_CODE_RESULT);
         } else {
           const errors = context.errors;


### PR DESCRIPTION
# Description

Do not merge. Just a hacky sample code for how result of default_js_slang can be obtained.
If possible, default_js_slang should be modified to process and return the result.
 
Added ability to receive callback with result when default_js_slang is used in repl module.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
