### PR TITLE
Bumping js-slang

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "classnames": "^2.3.1",
     "dayjs": "^1.10.4",
     "gl-matrix": "^3.3.0",
-    "js-slang": "^1.0.20",
+    "js-slang": "^1.0.48",
     "lodash": "^4.17.21",
     "patch-package": "^6.5.1",
     "phaser": "^3.54.0",

--- a/src/bundles/game/functions.ts
+++ b/src/bundles/game/functions.ts
@@ -188,6 +188,7 @@ export function create_config(lst: List): ObjectConfig {
       throw_error('config element is not a pair!');
     }
     config[head(xs)] = tail(xs);
+    return null;
   }, null, lst);
   return config;
 }

--- a/src/bundles/repl/programmable_repl.ts
+++ b/src/bundles/repl/programmable_repl.ts
@@ -197,7 +197,7 @@ export class ProgrammableRepl {
 
     runFilesInContext(sourceFile, '/ReplModuleUserCode.js', context, options)
       .then((evalResult) => {
-        if (evalResult.status === 'suspended' || evalResult.status === 'suspended-ec-eval') {
+        if (evalResult.status === 'suspended' || evalResult.status === 'suspended-cse-eval') {
           throw new Error('This should not happen');
         }
         if (evalResult.status !== 'error') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3053,7 +3053,7 @@ gpu-mock.js@^1.3.0:
   resolved "https://registry.yarnpkg.com/gpu-mock.js/-/gpu-mock.js-1.3.1.tgz#f7deaa09da3f672762eda944ecf948fd2c4b1490"
   integrity sha512-+lbp8rQ0p1nTa6Gk6HoLiw4yM6JTpql82U+nCF3sZbX4FJWP9PzzF1018dW8K+pbmqRmhLHbn6Bjc6i6tgUpbA==
 
-gpu.js@^2.10.4:
+gpu.js@^2.16.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/gpu.js/-/gpu.js-2.16.0.tgz#35531f8ee79292b71a454455e7bf0aaf6693182a"
   integrity sha512-ZKmWdRXi3F/9nim5ew2IPXZaMlSyqtMtVC8Itobjl+qYUgUqcBHxu8WKqK0AqIyjBVBl7A5ORo4Db2hzgrPd4A==
@@ -4007,15 +4007,20 @@ jest@^29.4.1:
     import-local "^3.0.2"
     jest-cli "^29.4.3"
 
+js-base64@^3.7.5:
+  version "3.7.7"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.7.tgz#e51b84bf78fbf5702b9541e2cb7bfcb893b43e79"
+  integrity sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==
+
 js-sdsl@^4.1.4:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.3.0.tgz#aeefe32a451f7af88425b11fdb5f58c90ae1d711"
   integrity sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==
 
-js-slang@^1.0.20:
-  version "1.0.20"
-  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-1.0.20.tgz#458c8e67234dde8eded2c5e21521efa3a3cea8a8"
-  integrity sha512-T/a2OX/xQYDPADhJq5vqD9wScJCz2aVIgroV8rB5vPEyPscfDWoxUhnAcQ4AXJY6eNMbr1hqII/e+kGPKesNlA==
+js-slang@^1.0.48:
+  version "1.0.48"
+  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-1.0.48.tgz#e08a52a8472eeb18c573e7a9700865746b7bcdbe"
+  integrity sha512-XaGdlbzZsMbA46f+5/IUXi2vUx3hlDA8ctneWSXOY7BMPduiUUrDJzL2y27enGZbE4l1V8E1prNehO7zfS6Xuw==
   dependencies:
     "@babel/parser" "^7.19.4"
     "@joeychenofficial/alt-ergo-modified" "^2.4.0"
@@ -4026,8 +4031,9 @@ js-slang@^1.0.20:
     acorn-loose "^8.0.0"
     acorn-walk "^8.0.0"
     astring "^1.4.3"
-    gpu.js "^2.10.4"
-    lodash "^4.17.20"
+    gpu.js "^2.16.0"
+    js-base64 "^3.7.5"
+    lodash "^4.17.21"
     node-getopt "^0.3.2"
     source-map "0.7.3"
     xmlhttprequest-ts "^1.0.1"
@@ -4222,7 +4228,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.14, lodash@^4.17.20, lodash@^4.17.21:
+lodash@^4.17.14, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
# Description
Bumped js-slang to match the frontend
In the pre-build script, it requires that `yarn build --lint --tsc` should be passed. However, changes in the naming of the js-slang ec-machine to cse-machine resulted in some regressions. This pull request fixes these regressions. 

No changes to existing functionality

Fixes # (issue)

Fix the type errors

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
It hasn't

# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] Any dependent changes have been merged and published in downstream modules
