### PR TITLE
Ev3 defensive tabs

### DIFF
--- a/src/bundles/robot_simulation/controllers/program/Program.ts
+++ b/src/bundles/robot_simulation/controllers/program/Program.ts
@@ -67,7 +67,7 @@ export class Program implements Controller {
 
       // steps per tick
       for (let i = 0; i < this.config.stepsPerTick; i++) {
-        const result = this.iterator.next();
+        this.iterator.next();
       }
     } catch (e) {
       console.error(e);

--- a/src/bundles/robot_simulation/engine/World.ts
+++ b/src/bundles/robot_simulation/engine/World.ts
@@ -30,7 +30,12 @@ export class World extends TypedEventTarget<WorldEventMap> {
   robotConsole: RobotConsole;
   controllers: ControllerGroup;
 
-  constructor(physics: Physics, render: Renderer, timer: Timer, robotConsole: RobotConsole) {
+  constructor(
+    physics: Physics,
+    render: Renderer,
+    timer: Timer,
+    robotConsole: RobotConsole
+  ) {
     super();
     this.state = 'unintialized';
     this.physics = physics;
@@ -71,10 +76,7 @@ export class World extends TypedEventTarget<WorldEventMap> {
 
   private setState(newState: WorldState) {
     if (this.state !== newState) {
-      this.dispatchEvent(
-        'worldStateChange',
-        new Event('worldStateChange'),
-      );
+      this.dispatchEvent('worldStateChange', new Event('worldStateChange'));
       this.state = newState;
     }
   }
@@ -90,6 +92,7 @@ export class World extends TypedEventTarget<WorldEventMap> {
       window.requestAnimationFrame(this.step.bind(this));
     }
   }
+
   step(timestamp: number) {
     try {
       const frameTimingInfo = this.timer.step(timestamp);
@@ -99,12 +102,12 @@ export class World extends TypedEventTarget<WorldEventMap> {
       // Update render
       this.dispatchEvent(
         'beforeRender',
-        new TimeStampedEvent('beforeRender', physicsTimingInfo),
+        new TimeStampedEvent('beforeRender', physicsTimingInfo)
       );
       this.render.step(frameTimingInfo);
       this.dispatchEvent(
         'afterRender',
-        new TimeStampedEvent('afterRender', physicsTimingInfo),
+        new TimeStampedEvent('afterRender', physicsTimingInfo)
       );
 
       if (this.state === 'running') {

--- a/src/tabs/RobotSimulation/components/Simulation/index.tsx
+++ b/src/tabs/RobotSimulation/components/Simulation/index.tsx
@@ -46,13 +46,16 @@ export const SimulationCanvas: React.FC<SimulationCanvasProps> = ({
 }) => {
   const ref = useRef<HTMLDivElement>(null);
   const sensorRef = useRef<HTMLDivElement>(null);
-  const [currentState, setCurrentState]
-    = useState<WorldState>('unintialized');
+  const [currentState, setCurrentState] = useState<WorldState>('unintialized');
+
+  // We know this is true because it is checked in RobotSimulation/index.tsx (toSpawn)
   const world = context.context.moduleContexts.robot_simulation.state
     .world as World;
 
-  const ev3 = context.context.moduleContexts.robot_simulation.state
-    .ev3 as DefaultEv3;
+  // This is not guaranteed to be true.
+  const ev3 = context.context.moduleContexts.robot_simulation.state.ev3 as
+    | DefaultEv3
+    | undefined;
 
   const robotConsole = world.robotConsole;
 
@@ -65,9 +68,14 @@ export const SimulationCanvas: React.FC<SimulationCanvasProps> = ({
       if (ref.current) {
         ref.current.replaceChildren(world.render.getElement());
       }
+      if (!ev3) {
+        return;
+      }
 
       if (sensorRef.current) {
-        sensorRef.current.replaceChildren(ev3.get('colorSensor').renderer.getElement());
+        sensorRef.current.replaceChildren(
+          ev3.get('colorSensor').renderer.getElement()
+        );
       }
     };
 

--- a/src/tabs/RobotSimulation/components/TabPanels/ColorSensorPanel.tsx
+++ b/src/tabs/RobotSimulation/components/TabPanels/ColorSensorPanel.tsx
@@ -4,24 +4,28 @@ import { useFetchFromSimulation } from '../../hooks/fetchFromSimulation';
 import { LastUpdated } from './tabComponents/LastUpdated';
 import { TabWrapper } from './tabComponents/Wrapper';
 
-export const ColorSensorPanel: React.FC<{ ev3: DefaultEv3 }> = ({ ev3 }) => {
-  const colorSensor = ev3.get('colorSensor');
+export const ColorSensorPanel: React.FC<{ ev3?: DefaultEv3 }> = ({ ev3 }) => {
+  const colorSensor = ev3?.get('colorSensor');
   const sensorVisionRef = useRef<HTMLDivElement>(null);
 
   const [timing, color] = useFetchFromSimulation(() => {
-    if (ev3.get('colorSensor') === undefined) {
+    if (colorSensor === undefined) {
       return null;
     }
     return colorSensor.sense();
   }, 1000);
 
   useEffect(() => {
-    if (sensorVisionRef.current) {
+    if (colorSensor && sensorVisionRef.current) {
       sensorVisionRef.current.replaceChildren(
         colorSensor.renderer.getElement()
       );
     }
   }, [timing]);
+
+  if (!ev3) {
+    return <TabWrapper>EV3 not found in context. Did you call saveToContext('ev3', ev3);</TabWrapper>;
+  }
 
   if (timing === null) {
     return <TabWrapper>Loading color sensor</TabWrapper>;

--- a/src/tabs/RobotSimulation/components/TabPanels/ConsolePanel.tsx
+++ b/src/tabs/RobotSimulation/components/TabPanels/ConsolePanel.tsx
@@ -17,7 +17,7 @@ const getLogString = (log: LogEntry) => {
 };
 
 export const ConsolePanel: React.FC<{
-  robot_console?: RobotConsole;
+  robot_console: RobotConsole;
 }> = ({ robot_console }) => {
   const [timing, logs] = useFetchFromSimulation(() => {
     if (robot_console === undefined) {

--- a/src/tabs/RobotSimulation/components/TabPanels/MotorPidPanel.tsx
+++ b/src/tabs/RobotSimulation/components/TabPanels/MotorPidPanel.tsx
@@ -9,7 +9,22 @@ const RowStyle: CSSProperties = {
   gap: '0.6rem',
 };
 
-export const MotorPidPanel: React.FC<{ ev3: DefaultEv3 }> = ({ ev3 }) => {
+export const MotorPidPanel: React.FC<{ ev3?: DefaultEv3 }> = ({ ev3 }) => {
+  if (!ev3) {
+    return (
+      <TabWrapper>
+        EV3 not found in context. Did you call saveToContext('ev3', ev3);
+      </TabWrapper>
+    );
+  }
+
+  const leftMotor = ev3.get('leftMotor');
+  const rightMotor = ev3.get('rightMotor');
+
+  if (!leftMotor || !rightMotor) {
+    return <TabWrapper>Motor not found</TabWrapper>;
+  }
+
   const onChangeProportional = (value: number) => {
     ev3.get('leftMotor').pid.proportionalGain = value;
     ev3.get('rightMotor').pid.proportionalGain = value;

--- a/src/tabs/RobotSimulation/components/TabPanels/UltrasonicSensorPanel.tsx
+++ b/src/tabs/RobotSimulation/components/TabPanels/UltrasonicSensorPanel.tsx
@@ -4,17 +4,24 @@ import { useFetchFromSimulation } from '../../hooks/fetchFromSimulation';
 import { LastUpdated } from './tabComponents/LastUpdated';
 import { TabWrapper } from './tabComponents/Wrapper';
 
-export const UltrasonicSensorPanel: React.FC<{ ev3: DefaultEv3 }> = ({
+export const UltrasonicSensorPanel: React.FC<{ ev3?: DefaultEv3 }> = ({
   ev3,
 }) => {
-  const ultrasonicSensor = ev3.get('ultrasonicSensor');
-
+  const ultrasonicSensor = ev3?.get('ultrasonicSensor');
   const [timing, distanceSensed] = useFetchFromSimulation(() => {
     if (ultrasonicSensor === undefined) {
       return null;
     }
     return ultrasonicSensor.sense();
   }, 1000);
+
+  if (!ev3) {
+    return (
+      <TabWrapper>
+        EV3 not found in context. Did you call saveToContext('ev3', ev3);
+      </TabWrapper>
+    );
+  }
 
   if (timing === null) {
     return <TabWrapper>Loading ultrasonic sensor</TabWrapper>;

--- a/src/tabs/RobotSimulation/components/TabPanels/WheelPidPanel.tsx
+++ b/src/tabs/RobotSimulation/components/TabPanels/WheelPidPanel.tsx
@@ -9,7 +9,23 @@ const RowStyle: CSSProperties = {
   gap: '0.6rem',
 };
 
-export const WheelPidPanel: React.FC<{ ev3: DefaultEv3 }> = ({ ev3 }) => {
+export const WheelPidPanel: React.FC<{ ev3?: DefaultEv3 }> = ({ ev3 }) => {
+  if (!ev3) {
+    return (
+      <TabWrapper>
+        EV3 not found in context. Did you call saveToContext('ev3', ev3);
+      </TabWrapper>
+    );
+  }
+  if (
+    !ev3.get('backLeftWheel') ||
+    !ev3.get('backRightWheel') ||
+    !ev3.get('frontLeftWheel') ||
+    !ev3.get('frontRightWheel')
+  ) {
+    return <TabWrapper>Wheel not found</TabWrapper>;
+  }
+
   const onChangeProportional = (value: number) => {
     ev3.get('backLeftWheel').pid.proportionalGain = value;
     ev3.get('backRightWheel').pid.proportionalGain = value;


### PR DESCRIPTION
# Description
Currently, ev3 tabs are not very defensive and throws unglamorously if the ev3 is not assigned in init_simulation. This is a minor change make the tabs more defensive

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
