### PR TITLE
REPL: Set program text

### DIFF
--- a/src/bundles/repl/functions.ts
+++ b/src/bundles/repl/functions.ts
@@ -103,6 +103,16 @@ export function set_font_size(font_size_px: number) {
 }
 
 /**
+ * Set program text
+ * @param {text} string
+ *
+ * @category Main
+ */
+export function set_program_text(text: string) {
+  INSTANCE.updateUserCode(text);
+}
+
+/**
  * When use this function as the entrance function in the parameter of "set_evaluator", the Programmable Repl will directly use the default js-slang interpreter to run your program in Programmable Repl editor. Do not directly call this function in your own code.
  * @param {program} Do not directly set this parameter in your code.
  * @param {safeKey} A parameter that is designed to prevent student from directly calling this function in Source language.

--- a/src/bundles/repl/functions.ts
+++ b/src/bundles/repl/functions.ts
@@ -103,7 +103,7 @@ export function set_font_size(font_size_px: number) {
 }
 
 /**
- * Set program text
+ * Set program text in the Repl editor to the given string
  * @param {text} string
  *
  * @category Main

--- a/src/bundles/repl/index.ts
+++ b/src/bundles/repl/index.ts
@@ -42,5 +42,6 @@ export {
   repl_display,
   set_background_image,
   set_font_size,
+  set_program_text,
   default_js_slang
 } from './functions';


### PR DESCRIPTION
# Description

Adds a simple function set_program_text to set the program text in the REPL editor to the given string.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

I built the modules locally and served them to my local frontend. That allowed me to check that the feature works as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
