### PR TITLE
draw_points_2d should show axes as well

### DIFF
--- a/src/bundles/plotly/functions.ts
+++ b/src/bundles/plotly/functions.ts
@@ -369,9 +369,9 @@ export const draw_points_2d = createPlotFunction(
   'scatter',
   { mode: 'markers' },
   {
-    xaxis: { visible: false },
+    xaxis: { visible: true },
     yaxis: {
-      visible: false,
+      visible: true,
       scaleanchor: 'x'
     }
   },


### PR DESCRIPTION
# Description

Follow up on #318 : draw_points_2d needs to show axes as well

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
