### PR TITLE
Add missing step to workflow

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Build Modules 🔧
         run: yarn workspaces foreach -ptW --from "./src/{bundles,tabs}/*" run build
 
+      - name: Build Manifest
+        run: yarn buildtools manifest
+
       - name: Build All Docs
         run: yarn build:docs
 


### PR DESCRIPTION
The Github Pages deployment workflow was missing the manifest building step. This PR fixes that.