### PR TITLE
Initial Conductor Migration (Repeat Module Migration, Testing, Documentation)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -285,6 +285,7 @@ export default defineConfig(
         }
       ],
       'prefer-const': ['warn', { destructuring: 'all' }],
+      'require-yield': 'off',
 
       '@sourceacademy/default-import-name': ['warn', { path: 'pathlib' }],
       '@sourceacademy/no-barrel-imports': ['error', ['lodash']],

--- a/lib/buildtools/src/build/docs/__tests__/conductor.test.ts
+++ b/lib/buildtools/src/build/docs/__tests__/conductor.test.ts
@@ -1,0 +1,216 @@
+import pathlib from 'path';
+import type { ResolvedBundle } from '@sourceacademy/modules-repotools/types';
+import * as td from 'typedoc';
+import { describe, expect, it, vi } from 'vitest';
+import { normalizeConductorDocs, normalizeConductorType } from '../conductor.js';
+import { initTypedocForJson } from '../typedoc.js';
+
+vi.setConfig({
+  testTimeout: 10000
+});
+
+function createProject() {
+  return new td.ProjectReflection('test', new td.FileRegistry());
+}
+
+function register<T extends td.Reflection>(project: td.ProjectReflection, reflection: T) {
+  project.registerReflection(reflection, undefined, undefined);
+  return reflection;
+}
+
+function conductorReference(project: td.ProjectReflection, name: string, qualifiedName = name) {
+  const reference = td.ReferenceType.createBrokenReference(name, project, '@sourceacademy/conductor');
+  reference.qualifiedName = qualifiedName;
+  return reference;
+}
+
+function dataType(project: td.ProjectReflection, name: string) {
+  return conductorReference(project, name, `DataType.${name}`);
+}
+
+function typedValue(project: td.ProjectReflection, typeName: string) {
+  const reference = conductorReference(project, 'ITypedValue');
+  reference.typeArguments = [dataType(project, typeName)];
+  return reference;
+}
+
+function asyncGenerator(project: td.ProjectReflection, returnType: td.SomeType) {
+  const reference = td.ReferenceType.createBrokenReference('AsyncGenerator', project, 'typescript');
+  reference.typeArguments = [
+    new td.IntrinsicType('void'),
+    returnType,
+    new td.UnknownType('unknown')
+  ];
+  return reference;
+}
+
+function createParameter(
+  project: td.ProjectReflection,
+  signature: td.SignatureReflection,
+  name: string,
+  type: td.SomeType
+) {
+  const parameter = register(
+    project,
+    new td.ParameterReflection(name, td.ReflectionKind.Parameter, signature)
+  );
+  parameter.type = type;
+  return parameter;
+}
+
+describe(normalizeConductorType, () => {
+  it('maps TypedValue numbers to native numbers', () => {
+    const project = createProject();
+    const normalized = normalizeConductorType(typedValue(project, 'NUMBER'), project);
+
+    expect(normalized.stringify(td.TypeContext.none)).toEqual('number');
+  });
+
+  it('maps closures to Function', () => {
+    const project = createProject();
+    const normalized = normalizeConductorType(typedValue(project, 'CLOSURE'), project);
+
+    expect(normalized.stringify(td.TypeContext.none)).toEqual('Function');
+  });
+
+  it('unwraps AsyncGenerator return values', () => {
+    const project = createProject();
+    const normalized = normalizeConductorType(
+      asyncGenerator(project, typedValue(project, 'NUMBER')),
+      project
+    );
+
+    expect(normalized.stringify(td.TypeContext.none)).toEqual('number');
+  });
+
+  it('leaves native types unchanged', () => {
+    const project = createProject();
+    const nativeType = new td.ArrayType(new td.IntrinsicType('string'));
+    const normalized = normalizeConductorType(nativeType, project);
+
+    expect(normalized.stringify(td.TypeContext.none)).toEqual('string[]');
+  });
+});
+
+describe(normalizeConductorDocs, () => {
+  it('promotes plugin methods and removes Conductor implementation details', () => {
+    const project = createProject();
+
+    const implementation = register(
+      project,
+      new td.DeclarationReflection('repeat', td.ReflectionKind.Function, project)
+    );
+    project.addChild(implementation);
+
+    const implementationSignature = register(
+      project,
+      new td.SignatureReflection('repeat', td.ReflectionKind.CallSignature, implementation)
+    );
+    implementation.signatures = [implementationSignature];
+    implementationSignature.comment = new td.Comment([
+      { kind: 'text', text: 'Returns a repeated function.' }
+    ]);
+    implementationSignature.parameters = [
+      createParameter(project, implementationSignature, 'evaluator', conductorReference(project, 'IDataHandler')),
+      createParameter(project, implementationSignature, 'func', typedValue(project, 'CLOSURE')),
+      createParameter(project, implementationSignature, 'n', typedValue(project, 'NUMBER'))
+    ];
+    implementationSignature.type = asyncGenerator(project, typedValue(project, 'CLOSURE'));
+
+    const plugin = register(
+      project,
+      new td.DeclarationReflection('default', td.ReflectionKind.Class, project)
+    );
+    project.addChild(plugin);
+    plugin.extendedTypes = [
+      conductorReference(project, 'RenamedModulePluginBase')
+    ];
+
+    const exportedNames = register(
+      project,
+      new td.DeclarationReflection('exportedNames', td.ReflectionKind.Property, plugin)
+    );
+    plugin.addChild(exportedNames);
+    exportedNames.type = new td.TypeOperatorType(
+      new td.TupleType([new td.LiteralType('repeat')]),
+      'readonly'
+    );
+
+    const method = register(
+      project,
+      new td.DeclarationReflection('repeat', td.ReflectionKind.Method, plugin)
+    );
+    plugin.addChild(method);
+
+    const methodSignature = register(
+      project,
+      new td.SignatureReflection('repeat', td.ReflectionKind.CallSignature, method)
+    );
+    method.signatures = [methodSignature];
+    methodSignature.parameters = [
+      createParameter(project, methodSignature, 'func', typedValue(project, 'CLOSURE')),
+      createParameter(project, methodSignature, 'n', typedValue(project, 'NUMBER'))
+    ];
+    methodSignature.type = asyncGenerator(project, typedValue(project, 'CLOSURE'));
+
+    const classesGroup = new td.ReflectionGroup('Classes', project);
+    classesGroup.children = [plugin];
+    const functionsGroup = new td.ReflectionGroup('Functions', project);
+    functionsGroup.children = [implementation];
+    project.groups = [classesGroup, functionsGroup];
+
+    normalizeConductorDocs(project);
+
+    expect(project.children?.map(child => child.name)).toEqual(['repeat']);
+    expect(project.groups?.map(group => group.title)).toEqual(['Functions']);
+
+    const publicFunction = project.children?.[0];
+    expect(publicFunction?.kind).toEqual(td.ReflectionKind.Function);
+
+    const [signature] = publicFunction?.signatures ?? [];
+    expect(signature.comment?.summary.map(({ text }) => text).join('')).toEqual('Returns a repeated function.');
+    expect(signature.parameters?.map(parameter => [
+      parameter.name,
+      parameter.type?.stringify(td.TypeContext.none)
+    ])).toEqual([
+      ['func', 'Function'],
+      ['n', 'number']
+    ]);
+    expect(signature.type?.stringify(td.TypeContext.none)).toEqual('Function');
+  });
+
+  it('normalizes the migrated repeat bundle docs', async () => {
+    const repeatBundle: ResolvedBundle = {
+      type: 'bundle',
+      name: 'repeat',
+      manifest: {},
+      directory: pathlib.resolve(import.meta.dirname, '../../../../../../src/bundles/repeat')
+    };
+    const app = await initTypedocForJson(repeatBundle, td.LogLevel.None);
+    const project = await app.convert();
+    expect(project).toBeDefined();
+
+    normalizeConductorDocs(project!);
+
+    const names = project!.children?.map(child => child.name);
+    expect(names).toEqual(expect.arrayContaining(['repeat', 'twice', 'thrice']));
+    expect(names).not.toContain('default');
+
+    const publicFunctions = project!.children?.filter(child => {
+      return child.kind === td.ReflectionKind.Function
+        && ['repeat', 'twice', 'thrice'].includes(child.name);
+    }) ?? [];
+    const signatureText = publicFunctions
+      .flatMap(func => func.signatures ?? [])
+      .map(signature => [
+        signature.parameters?.map(parameter => parameter.type?.stringify(td.TypeContext.none)).join(', '),
+        signature.type?.stringify(td.TypeContext.none)
+      ].join(' => '))
+      .join('\n');
+
+    expect(signatureText).not.toContain('AsyncGenerator');
+    expect(signatureText).not.toContain('ITypedValue');
+    expect(publicFunctions.find(func => func.name === 'repeat')?.signatures?.[0].parameters?.map(parameter => parameter.name))
+      .toEqual(['func', 'n']);
+  });
+});

--- a/lib/buildtools/src/build/docs/__tests__/conductor.test.ts
+++ b/lib/buildtools/src/build/docs/__tests__/conductor.test.ts
@@ -2,7 +2,7 @@ import pathlib from 'path';
 import type { ResolvedBundle } from '@sourceacademy/modules-repotools/types';
 import * as td from 'typedoc';
 import { describe, expect, it, vi } from 'vitest';
-import { normalizeConductorDocs, normalizeConductorType } from '../conductor.js';
+import { normalizeConductorDocs, normalizeConductorType } from '../conductor/index.js';
 import { initTypedocForJson } from '../typedoc.js';
 
 vi.setConfig({

--- a/lib/buildtools/src/build/docs/conductor.ts
+++ b/lib/buildtools/src/build/docs/conductor.ts
@@ -1,0 +1,543 @@
+import * as td from 'typedoc';
+
+const CONDUCTOR_PACKAGE = '@sourceacademy/conductor';
+const TYPED_VALUE_NAMES = new Set(['TypedValue', 'ITypedValue']);
+const SERVICE_PARAMETER_TYPES = new Set([
+  'IDataHandler',
+  'IInterfacableEvaluator',
+  'IChannel',
+  'IConduit'
+]);
+
+const DATA_TYPE_NAMES = new Set([
+  'VOID',
+  'BOOLEAN',
+  'NUMBER',
+  'CONST_STRING',
+  'EMPTY_LIST',
+  'PAIR',
+  'ARRAY',
+  'CLOSURE',
+  'OPAQUE',
+  'LIST'
+]);
+
+/**
+ * Narrows a TypeDoc type to references, which is how Conductor transport types appear.
+ */
+function isReferenceType(type: td.SomeType | undefined): type is td.ReferenceType {
+  return type instanceof td.ReferenceType;
+}
+
+/**
+ * Checks whether a reference points at one of the Conductor symbols this normalizer understands.
+ */
+function isConductorReference(type: td.ReferenceType, names: Set<string>) {
+  return names.has(type.name) && (!type.package || type.package === CONDUCTOR_PACKAGE);
+}
+
+/**
+ * Detects `DataType.X` references inside `TypedValue`/`ITypedValue` type arguments.
+ */
+function isDataTypeReference(type: td.SomeType | undefined): type is td.ReferenceType {
+  if (!isReferenceType(type)) return false;
+
+  const qualifiedName = type.qualifiedName ?? type.name;
+  return DATA_TYPE_NAMES.has(type.name)
+    && (qualifiedName === type.name || qualifiedName === `DataType.${type.name}`);
+}
+
+/**
+ * Returns the enum member name from a Conductor `DataType.X` type reference.
+ */
+function getDataTypeName(type: td.SomeType | undefined) {
+  return isDataTypeReference(type) ? type.name : undefined;
+}
+
+/**
+ * Creates an unresolved public-facing type name that TypeDoc renders as plain text.
+ */
+function namedType(name: string, project: td.ProjectReflection) {
+  return td.ReferenceType.createBrokenReference(name, project, undefined);
+}
+
+/**
+ * Converts a Conductor `DataType` enum member to the type shown to module users.
+ */
+function dataTypeToNativeType(dataType: string | undefined, project: td.ProjectReflection): td.SomeType {
+  switch (dataType) {
+    case 'VOID':
+      return new td.IntrinsicType('void');
+    case 'BOOLEAN':
+      return new td.IntrinsicType('boolean');
+    case 'NUMBER':
+      return new td.IntrinsicType('number');
+    case 'CONST_STRING':
+      return new td.IntrinsicType('string');
+    case 'EMPTY_LIST':
+      return new td.LiteralType(null);
+    case 'PAIR':
+      return namedType('Pair', project);
+    case 'ARRAY':
+      return new td.ArrayType(new td.UnknownType('unknown'));
+    case 'CLOSURE':
+      return namedType('Function', project);
+    case 'OPAQUE':
+      return new td.UnknownType('unknown');
+    case 'LIST':
+      return namedType('List', project);
+    default:
+      return new td.UnknownType('unknown');
+  }
+}
+
+/**
+ * Copies visibility and modifier flags when replacing TypeDoc reflection nodes.
+ */
+function cloneFlags(source: td.Reflection, target: td.Reflection) {
+  target.flags.fromObject(source.flags.toObject());
+}
+
+/**
+ * Normalizes every type argument in a reference or tuple-like TypeDoc type.
+ */
+function normalizeTypeList(types: td.SomeType[] | undefined, project: td.ProjectReflection) {
+  return types?.map(type => normalizeConductorType(type, project));
+}
+
+/**
+ * Converts Conductor transport types to the native values that module users see.
+ */
+export function normalizeConductorType(type: td.SomeType, project: td.ProjectReflection): td.SomeType {
+  if (type instanceof td.ReferenceType) {
+    if (isConductorReference(type, TYPED_VALUE_NAMES)) {
+      return dataTypeToNativeType(getDataTypeName(type.typeArguments?.[0]), project);
+    }
+
+    if (type.name === 'AsyncGenerator' && type.typeArguments?.[1]) {
+      return normalizeConductorType(type.typeArguments[1], project);
+    }
+
+    type.typeArguments = normalizeTypeList(type.typeArguments, project);
+    return type;
+  }
+
+  if (type instanceof td.ArrayType) {
+    type.elementType = normalizeConductorType(type.elementType, project);
+    return type;
+  }
+
+  if (type instanceof td.ConditionalType) {
+    type.checkType = normalizeConductorType(type.checkType, project);
+    type.extendsType = normalizeConductorType(type.extendsType, project);
+    type.trueType = normalizeConductorType(type.trueType, project);
+    type.falseType = normalizeConductorType(type.falseType, project);
+    return type;
+  }
+
+  if (type instanceof td.IndexedAccessType) {
+    type.objectType = normalizeConductorType(type.objectType, project);
+    type.indexType = normalizeConductorType(type.indexType, project);
+    return type;
+  }
+
+  if (type instanceof td.InferredType) {
+    if (type.constraint) {
+      type.constraint = normalizeConductorType(type.constraint, project);
+    }
+    return type;
+  }
+
+  if (type instanceof td.IntersectionType || type instanceof td.UnionType) {
+    type.types = type.types.map(each => normalizeConductorType(each, project));
+    return type;
+  }
+
+  if (type instanceof td.MappedType) {
+    type.parameterType = normalizeConductorType(type.parameterType, project);
+    type.templateType = normalizeConductorType(type.templateType, project);
+    if (type.nameType) {
+      type.nameType = normalizeConductorType(type.nameType, project);
+    }
+    return type;
+  }
+
+  if (type instanceof td.OptionalType || type instanceof td.RestType) {
+    type.elementType = normalizeConductorType(type.elementType, project);
+    return type;
+  }
+
+  if (type instanceof td.PredicateType) {
+    if (type.targetType) {
+      type.targetType = normalizeConductorType(type.targetType, project);
+    }
+    return type;
+  }
+
+  if (type instanceof td.ReflectionType) {
+    normalizeDeclaration(type.declaration, project);
+    return type;
+  }
+
+  if (type instanceof td.TupleType) {
+    type.elements = type.elements.map(each => normalizeConductorType(each, project));
+    return type;
+  }
+
+  if (type instanceof td.NamedTupleMember) {
+    type.element = normalizeConductorType(type.element, project);
+    return type;
+  }
+
+  if (type instanceof td.TypeOperatorType) {
+    type.target = normalizeConductorType(type.target, project);
+    return type;
+  }
+
+  if (type instanceof td.TemplateLiteralType) {
+    type.tail = type.tail.map(([tailType, text]) => [
+      normalizeConductorType(tailType, project),
+      text
+    ]);
+    return type;
+  }
+
+  return type;
+}
+
+/**
+ * Identifies evaluator/conduit parameters that are implementation plumbing, not public API.
+ */
+function isServiceParameter(parameter: td.ParameterReflection) {
+  if (!isReferenceType(parameter.type)) return false;
+  return isConductorReference(parameter.type, SERVICE_PARAMETER_TYPES);
+}
+
+/**
+ * Rewrites one call signature from Conductor-facing types to public module-facing types.
+ */
+function normalizeSignature(signature: td.SignatureReflection, project: td.ProjectReflection) {
+  if (signature.type) {
+    project.removeTypeReflections(signature.type);
+    signature.type = normalizeConductorType(signature.type, project);
+  }
+
+  signature.parameters = signature.parameters
+    ?.filter(parameter => !isServiceParameter(parameter))
+    .map(parameter => {
+      if (parameter.type) {
+        project.removeTypeReflections(parameter.type);
+        parameter.type = normalizeConductorType(parameter.type, project);
+      }
+      return parameter;
+    });
+}
+
+/**
+ * Applies signature/type normalization to a declaration and its accessors.
+ */
+function normalizeDeclaration(declaration: td.DeclarationReflection, project: td.ProjectReflection) {
+  if (declaration.type) {
+    project.removeTypeReflections(declaration.type);
+    declaration.type = normalizeConductorType(declaration.type, project);
+  }
+
+  declaration.signatures?.forEach(signature => normalizeSignature(signature, project));
+  declaration.indexSignatures?.forEach(signature => normalizeSignature(signature, project));
+
+  if (declaration.getSignature) {
+    normalizeSignature(declaration.getSignature, project);
+  }
+
+  if (declaration.setSignature) {
+    normalizeSignature(declaration.setSignature, project);
+  }
+}
+
+/**
+ * Detects migrated module plugin classes without depending on the concrete base-class name.
+ */
+function isConductorPluginClass(reflection: td.DeclarationReflection) {
+  if (reflection.kind !== td.ReflectionKind.Class) return false;
+
+  const exportedNames = getExportedNames(reflection);
+  if (exportedNames.size === 0) return false;
+
+  return reflection.children?.some(child => isExportedConductorMethod(child, exportedNames)) ?? false;
+}
+
+/**
+ * Extracts string literal values from the tuple/union TypeDoc emits for `exportedNames`.
+ */
+function getStringLiterals(type: td.SomeType | undefined): string[] {
+  if (type instanceof td.TypeOperatorType) {
+    return getStringLiterals(type.target);
+  }
+
+  if (type instanceof td.TupleType) {
+    return type.elements.flatMap(getStringLiterals);
+  }
+
+  if (type instanceof td.UnionType) {
+    return type.types.flatMap(getStringLiterals);
+  }
+
+  if (type instanceof td.LiteralType && typeof type.value === 'string') {
+    return [type.value];
+  }
+
+  return [];
+}
+
+/**
+ * Reads the authoritative list of public module exports from a plugin class.
+ */
+function getExportedNames(plugin: td.DeclarationReflection) {
+  const exportedNames = plugin.children?.find(child => child.name === 'exportedNames');
+  return new Set(getStringLiterals(exportedNames?.type));
+}
+
+/**
+ * Checks whether a type tree contains Conductor transport wrappers.
+ */
+function hasConductorTransportType(type: td.SomeType | undefined): boolean {
+  if (!type) return false;
+
+  if (type instanceof td.ReferenceType) {
+    if (isConductorReference(type, TYPED_VALUE_NAMES)) {
+      return true;
+    }
+
+    return type.typeArguments?.some(hasConductorTransportType) ?? false;
+  }
+
+  if (type instanceof td.ArrayType) {
+    return hasConductorTransportType(type.elementType);
+  }
+
+  if (type instanceof td.UnionType || type instanceof td.IntersectionType) {
+    return type.types.some(hasConductorTransportType);
+  }
+
+  if (type instanceof td.TypeOperatorType) {
+    return hasConductorTransportType(type.target);
+  }
+
+  if (type instanceof td.TupleType) {
+    return type.elements.some(hasConductorTransportType);
+  }
+
+  return false;
+}
+
+/**
+ * Determines whether a class method is both publicly exported and Conductor-shaped.
+ */
+function isExportedConductorMethod(
+  child: td.DeclarationReflection,
+  exportedNames: Set<string>
+) {
+  if (child.kind !== td.ReflectionKind.Method || !exportedNames.has(child.name)) {
+    return false;
+  }
+
+  return child.signatures?.some(signature => {
+    return hasConductorTransportType(signature.type)
+      || signature.parameters?.some(parameter => hasConductorTransportType(parameter.type));
+  }) ?? false;
+}
+
+/**
+ * Prefers implementation JSDoc over wrapper-method JSDoc when both are available.
+ */
+function getSignatureComment(
+  implementationSignature: td.SignatureReflection | undefined,
+  pluginSignature: td.SignatureReflection
+) {
+  return implementationSignature?.comment ?? pluginSignature.comment;
+}
+
+/**
+ * Copies a method parameter onto a public function signature with normalized type/comment data.
+ */
+function cloneParameter(
+  parameter: td.ParameterReflection,
+  parent: td.SignatureReflection,
+  project: td.ProjectReflection,
+  commentSource: td.ParameterReflection | undefined
+) {
+  const clone = new td.ParameterReflection(parameter.name, td.ReflectionKind.Parameter, parent);
+  cloneFlags(parameter, clone);
+  clone.comment = commentSource?.comment ?? parameter.comment;
+  clone.defaultValue = parameter.defaultValue;
+  clone.type = parameter.type ? normalizeConductorType(parameter.type, project) : undefined;
+  project.registerReflection(clone, undefined, undefined);
+  return clone;
+}
+
+/**
+ * Builds the public function signature from the plugin method and matching implementation docs.
+ */
+function copyPluginSignature(
+  target: td.DeclarationReflection,
+  pluginSignature: td.SignatureReflection,
+  project: td.ProjectReflection,
+  implementationSignature: td.SignatureReflection | undefined
+) {
+  const targetSignature = target.signatures?.[0]
+    ?? new td.SignatureReflection(target.name, td.ReflectionKind.CallSignature, target);
+
+  if (!target.signatures?.includes(targetSignature)) {
+    target.signatures = [targetSignature];
+    project.registerReflection(targetSignature, undefined, undefined);
+  }
+
+  cloneFlags(pluginSignature, targetSignature);
+  targetSignature.comment = getSignatureComment(implementationSignature, pluginSignature);
+  targetSignature.type = pluginSignature.type
+    ? normalizeConductorType(pluginSignature.type, project)
+    : undefined;
+
+  targetSignature.parameters = pluginSignature.parameters?.map(parameter => {
+    const implementationParameter = implementationSignature?.parameters
+      ?.find(each => each.name === parameter.name);
+    return cloneParameter(parameter, targetSignature, project, implementationParameter);
+  });
+}
+
+/**
+ * Finds an existing top-level function reflection for a module export.
+ */
+function findPublicFunction(container: td.ContainerReflection, name: string) {
+  return container.children?.find(child => {
+    return child.name === name
+      && child.kind === td.ReflectionKind.Function;
+  });
+}
+
+/**
+ * Creates a new top-level function reflection when the plugin method has no implementation twin.
+ */
+function createPublicFunction(
+  container: td.ContainerReflection,
+  name: string,
+  project: td.ProjectReflection
+) {
+  const reflection = new td.DeclarationReflection(name, td.ReflectionKind.Function, container);
+  container.addChild(reflection);
+  project.registerReflection(reflection, undefined, undefined);
+  return reflection;
+}
+
+/**
+ * Converts exported plugin methods into top-level functions and merges their public docs.
+ */
+function promotePluginMethods(
+  container: td.ContainerReflection,
+  plugin: td.DeclarationReflection,
+  project: td.ProjectReflection
+) {
+  const exportedNames = getExportedNames(plugin);
+
+  plugin.children
+    ?.filter(child => child.kind === td.ReflectionKind.Method && exportedNames.has(child.name))
+    .forEach(method => {
+      const pluginSignature = method.signatures?.[0];
+      if (!pluginSignature) return;
+
+      const publicFunction = findPublicFunction(container, method.name)
+        ?? createPublicFunction(container, method.name, project);
+      const implementationSignature = publicFunction.signatures?.[0];
+
+      copyPluginSignature(publicFunction, pluginSignature, project, implementationSignature);
+    });
+}
+
+/**
+ * Preserves explicit `@group` tags, otherwise derives the default TypeDoc group title.
+ */
+function groupNamesFor(reflection: td.DeclarationReflection | td.DocumentReflection) {
+  const explicitGroups = reflection.comment?.blockTags
+    .filter(tag => tag.tag === '@group')
+    .map(tag => td.Comment.combineDisplayParts(tag.content).trim())
+    .filter(Boolean);
+
+  return explicitGroups?.length
+    ? explicitGroups
+    : [td.ReflectionKind.pluralString(reflection.kind)];
+}
+
+/**
+ * Reconciles TypeDoc groups after removing plugin classes and adding promoted functions.
+ */
+function syncGroups(container: td.ContainerReflection) {
+  const children = container.childrenIncludingDocuments ?? [];
+  const childSet = new Set(children);
+  const groupedChildren = new Set<td.DeclarationReflection | td.DocumentReflection>();
+
+  container.groups = container.groups
+    ?.map(group => {
+      group.children = group.children.filter(child => childSet.has(child));
+      group.children.forEach(child => groupedChildren.add(child));
+      delete group.categories;
+      return group;
+    })
+    .filter(group => group.children.length > 0);
+
+  children
+    .filter(child => !groupedChildren.has(child))
+    .forEach(child => {
+      groupNamesFor(child).forEach(groupName => {
+        let group = container.groups?.find(each => each.title === groupName);
+        if (!group) {
+          group = new td.ReflectionGroup(groupName, container);
+          const groups = container.groups ?? [];
+          container.groups = [...groups, group];
+        }
+
+        group.children.push(child);
+      });
+    });
+
+  if (container.groups?.length === 0) {
+    delete container.groups;
+  }
+
+  delete container.categories;
+}
+
+/**
+ * Normalizes one container and recursively visits nested modules/namespaces.
+ */
+function normalizeContainer(container: td.ContainerReflection, project: td.ProjectReflection): boolean {
+  let mutated = false;
+  const pluginClasses = container.children?.filter(isConductorPluginClass) ?? [];
+
+  pluginClasses.forEach(plugin => {
+    promotePluginMethods(container, plugin, project);
+    project.removeReflection(plugin);
+    mutated = true;
+  });
+
+  container.children?.forEach(child => {
+    normalizeDeclaration(child, project);
+
+    if (child.isContainer()) {
+      const childMutated = normalizeContainer(child, project);
+      mutated = mutated || childMutated;
+    }
+  });
+
+  if (mutated) {
+    syncGroups(container);
+  }
+
+  return mutated;
+}
+
+/**
+ * Rewrites Conductor module implementation details into the public API surface.
+ */
+export function normalizeConductorDocs(project: td.ProjectReflection) {
+  normalizeContainer(project, project);
+}

--- a/lib/buildtools/src/build/docs/conductor.ts
+++ b/lib/buildtools/src/build/docs/conductor.ts
@@ -458,9 +458,9 @@ function promotePluginMethods(
  */
 function groupNamesFor(reflection: td.DeclarationReflection | td.DocumentReflection) {
   const explicitGroups = reflection.comment?.blockTags
-    .filter(tag => tag.tag === '@group')
-    .map(tag => td.Comment.combineDisplayParts(tag.content).trim())
-    .filter(Boolean);
+    ?.filter(tag => tag.tag === '@group')
+    ?.map(tag => td.Comment.combineDisplayParts(tag.content).trim())
+    ?.filter(Boolean);
 
   return explicitGroups?.length
     ? explicitGroups

--- a/lib/buildtools/src/build/docs/conductor/constants.ts
+++ b/lib/buildtools/src/build/docs/conductor/constants.ts
@@ -1,0 +1,21 @@
+export const CONDUCTOR_PACKAGE = '@sourceacademy/conductor';
+export const TYPED_VALUE_NAMES = new Set(['TypedValue', 'ITypedValue']);
+export const SERVICE_PARAMETER_TYPES = new Set([
+  'IDataHandler',
+  'IInterfacableEvaluator',
+  'IChannel',
+  'IConduit'
+]);
+
+export const DATA_TYPE_NAMES = new Set([
+  'VOID',
+  'BOOLEAN',
+  'NUMBER',
+  'CONST_STRING',
+  'EMPTY_LIST',
+  'PAIR',
+  'ARRAY',
+  'CLOSURE',
+  'OPAQUE',
+  'LIST'
+]);

--- a/lib/buildtools/src/build/docs/conductor/index.ts
+++ b/lib/buildtools/src/build/docs/conductor/index.ts
@@ -1,0 +1,1 @@
+export { normalizeConductorDocs, normalizeConductorType } from './normalisation.js';

--- a/lib/buildtools/src/build/docs/conductor/normalisation.ts
+++ b/lib/buildtools/src/build/docs/conductor/normalisation.ts
@@ -1,0 +1,187 @@
+import * as td from 'typedoc';
+import { TYPED_VALUE_NAMES } from './constants.js';
+import { dataTypeToNativeType, getDataTypeName, isConductorPluginClass, isConductorReference, isServiceParameter, promotePluginMethods, syncGroups } from './utils.js';
+
+/**
+ * Rewrites one call signature from Conductor-facing types to public module-facing types.
+ */
+function normalizeSignature(signature: td.SignatureReflection, project: td.ProjectReflection) {
+  if (signature.type) {
+    project.removeTypeReflections(signature.type);
+    signature.type = normalizeConductorType(signature.type, project);
+  }
+
+  signature.parameters = signature.parameters
+    ?.filter(parameter => !isServiceParameter(parameter))
+    .map(parameter => {
+      if (parameter.type) {
+        project.removeTypeReflections(parameter.type);
+        parameter.type = normalizeConductorType(parameter.type, project);
+      }
+      return parameter;
+    });
+}
+
+/**
+ * Converts Conductor transport types to the native values that module users see.
+ */
+export function normalizeConductorType(type: td.SomeType, project: td.ProjectReflection): td.SomeType {
+  if (type instanceof td.ReferenceType) {
+    if (isConductorReference(type, TYPED_VALUE_NAMES)) {
+      return dataTypeToNativeType(getDataTypeName(type.typeArguments?.[0]), project);
+    }
+
+    if (type.name === 'AsyncGenerator' && type.typeArguments?.[1]) {
+      return normalizeConductorType(type.typeArguments[1], project);
+    }
+
+    type.typeArguments = normalizeTypeList(type.typeArguments, project);
+    return type;
+  }
+
+  if (type instanceof td.ArrayType) {
+    type.elementType = normalizeConductorType(type.elementType, project);
+    return type;
+  }
+
+  if (type instanceof td.ConditionalType) {
+    type.checkType = normalizeConductorType(type.checkType, project);
+    type.extendsType = normalizeConductorType(type.extendsType, project);
+    type.trueType = normalizeConductorType(type.trueType, project);
+    type.falseType = normalizeConductorType(type.falseType, project);
+    return type;
+  }
+
+  if (type instanceof td.IndexedAccessType) {
+    type.objectType = normalizeConductorType(type.objectType, project);
+    type.indexType = normalizeConductorType(type.indexType, project);
+    return type;
+  }
+
+  if (type instanceof td.InferredType) {
+    if (type.constraint) {
+      type.constraint = normalizeConductorType(type.constraint, project);
+    }
+    return type;
+  }
+
+  if (type instanceof td.IntersectionType || type instanceof td.UnionType) {
+    type.types = type.types.map(each => normalizeConductorType(each, project));
+    return type;
+  }
+
+  if (type instanceof td.MappedType) {
+    type.parameterType = normalizeConductorType(type.parameterType, project);
+    type.templateType = normalizeConductorType(type.templateType, project);
+    if (type.nameType) {
+      type.nameType = normalizeConductorType(type.nameType, project);
+    }
+    return type;
+  }
+
+  if (type instanceof td.OptionalType || type instanceof td.RestType) {
+    type.elementType = normalizeConductorType(type.elementType, project);
+    return type;
+  }
+
+  if (type instanceof td.PredicateType) {
+    if (type.targetType) {
+      type.targetType = normalizeConductorType(type.targetType, project);
+    }
+    return type;
+  }
+
+  if (type instanceof td.ReflectionType) {
+    normalizeDeclaration(type.declaration, project);
+    return type;
+  }
+
+  if (type instanceof td.TupleType) {
+    type.elements = type.elements.map(each => normalizeConductorType(each, project));
+    return type;
+  }
+
+  if (type instanceof td.NamedTupleMember) {
+    type.element = normalizeConductorType(type.element, project);
+    return type;
+  }
+
+  if (type instanceof td.TypeOperatorType) {
+    type.target = normalizeConductorType(type.target, project);
+    return type;
+  }
+
+  if (type instanceof td.TemplateLiteralType) {
+    type.tail = type.tail.map(([tailType, text]) => [
+      normalizeConductorType(tailType, project),
+      text
+    ]);
+    return type;
+  }
+
+  return type;
+}
+
+/**
+ * Applies signature/type normalization to a declaration and its accessors.
+ */
+function normalizeDeclaration(declaration: td.DeclarationReflection, project: td.ProjectReflection) {
+  if (declaration.type) {
+    project.removeTypeReflections(declaration.type);
+    declaration.type = normalizeConductorType(declaration.type, project);
+  }
+
+  declaration.signatures?.forEach(signature => normalizeSignature(signature, project));
+  declaration.indexSignatures?.forEach(signature => normalizeSignature(signature, project));
+
+  if (declaration.getSignature) {
+    normalizeSignature(declaration.getSignature, project);
+  }
+
+  if (declaration.setSignature) {
+    normalizeSignature(declaration.setSignature, project);
+  }
+}
+
+/**
+ * Normalizes one container and recursively visits nested modules/namespaces.
+ */
+function normalizeContainer(container: td.ContainerReflection, project: td.ProjectReflection): boolean {
+  let mutated = false;
+  const pluginClasses = container.children?.filter(isConductorPluginClass) ?? [];
+
+  pluginClasses.forEach(plugin => {
+    promotePluginMethods(container, plugin, project);
+    project.removeReflection(plugin);
+    mutated = true;
+  });
+
+  container.children?.forEach(child => {
+    normalizeDeclaration(child, project);
+
+    if (child.isContainer()) {
+      const childMutated = normalizeContainer(child, project);
+      mutated = mutated || childMutated;
+    }
+  });
+
+  if (mutated) {
+    syncGroups(container);
+  }
+
+  return mutated;
+}
+
+/**
+ * Rewrites Conductor module implementation details into the public API surface.
+ */
+export function normalizeConductorDocs(project: td.ProjectReflection) {
+  normalizeContainer(project, project);
+}
+
+/**
+ * Normalizes every type argument in a reference or tuple-like TypeDoc type.
+ */
+function normalizeTypeList(types: td.SomeType[] | undefined, project: td.ProjectReflection) {
+  return types?.map(type => normalizeConductorType(type, project));
+}

--- a/lib/buildtools/src/build/docs/conductor/utils.ts
+++ b/lib/buildtools/src/build/docs/conductor/utils.ts
@@ -1,70 +1,50 @@
 import * as td from 'typedoc';
-
-const CONDUCTOR_PACKAGE = '@sourceacademy/conductor';
-const TYPED_VALUE_NAMES = new Set(['TypedValue', 'ITypedValue']);
-const SERVICE_PARAMETER_TYPES = new Set([
-  'IDataHandler',
-  'IInterfacableEvaluator',
-  'IChannel',
-  'IConduit'
-]);
-
-const DATA_TYPE_NAMES = new Set([
-  'VOID',
-  'BOOLEAN',
-  'NUMBER',
-  'CONST_STRING',
-  'EMPTY_LIST',
-  'PAIR',
-  'ARRAY',
-  'CLOSURE',
-  'OPAQUE',
-  'LIST'
-]);
+import { CONDUCTOR_PACKAGE, DATA_TYPE_NAMES, SERVICE_PARAMETER_TYPES, TYPED_VALUE_NAMES } from './constants.js';
+import { normalizeConductorType } from './normalisation.js';
 
 /**
  * Narrows a TypeDoc type to references, which is how Conductor transport types appear.
  */
-function isReferenceType(type: td.SomeType | undefined): type is td.ReferenceType {
+export function isReferenceType(type: td.SomeType | undefined): type is td.ReferenceType {
   return type instanceof td.ReferenceType;
 }
 
 /**
  * Checks whether a reference points at one of the Conductor symbols this normalizer understands.
  */
-function isConductorReference(type: td.ReferenceType, names: Set<string>) {
+export function isConductorReference(type: td.ReferenceType, names: Set<string>) {
   return names.has(type.name) && (!type.package || type.package === CONDUCTOR_PACKAGE);
 }
 
 /**
  * Detects `DataType.X` references inside `TypedValue`/`ITypedValue` type arguments.
  */
-function isDataTypeReference(type: td.SomeType | undefined): type is td.ReferenceType {
+export function isDataTypeReference(type: td.SomeType | undefined): type is td.ReferenceType {
   if (!isReferenceType(type)) return false;
 
   const qualifiedName = type.qualifiedName ?? type.name;
   return DATA_TYPE_NAMES.has(type.name)
-    && (qualifiedName === type.name || qualifiedName === `DataType.${type.name}`);
+        && (qualifiedName === type.name || qualifiedName === `DataType.${type.name}`);
 }
 
 /**
  * Returns the enum member name from a Conductor `DataType.X` type reference.
  */
-function getDataTypeName(type: td.SomeType | undefined) {
+export function getDataTypeName(type: td.SomeType | undefined) {
   return isDataTypeReference(type) ? type.name : undefined;
 }
 
 /**
  * Creates an unresolved public-facing type name that TypeDoc renders as plain text.
  */
-function namedType(name: string, project: td.ProjectReflection) {
+export function namedType(name: string, project: td.ProjectReflection) {
   return td.ReferenceType.createBrokenReference(name, project, undefined);
 }
 
 /**
  * Converts a Conductor `DataType` enum member to the type shown to module users.
  */
-function dataTypeToNativeType(dataType: string | undefined, project: td.ProjectReflection): td.SomeType {
+export function dataTypeToNativeType(dataType: string | undefined, project: td.ProjectReflection): td.SomeType {
   switch (dataType) {
     case 'VOID':
       return new td.IntrinsicType('void');
@@ -92,172 +72,17 @@ function dataTypeToNativeType(dataType: string | undefined, project: td.ProjectR
 }
 
 /**
- * Copies visibility and modifier flags when replacing TypeDoc reflection nodes.
- */
-function cloneFlags(source: td.Reflection, target: td.Reflection) {
-  target.flags.fromObject(source.flags.toObject());
-}
-
-/**
- * Normalizes every type argument in a reference or tuple-like TypeDoc type.
- */
-function normalizeTypeList(types: td.SomeType[] | undefined, project: td.ProjectReflection) {
-  return types?.map(type => normalizeConductorType(type, project));
-}
-
-/**
- * Converts Conductor transport types to the native values that module users see.
- */
-export function normalizeConductorType(type: td.SomeType, project: td.ProjectReflection): td.SomeType {
-  if (type instanceof td.ReferenceType) {
-    if (isConductorReference(type, TYPED_VALUE_NAMES)) {
-      return dataTypeToNativeType(getDataTypeName(type.typeArguments?.[0]), project);
-    }
-
-    if (type.name === 'AsyncGenerator' && type.typeArguments?.[1]) {
-      return normalizeConductorType(type.typeArguments[1], project);
-    }
-
-    type.typeArguments = normalizeTypeList(type.typeArguments, project);
-    return type;
-  }
-
-  if (type instanceof td.ArrayType) {
-    type.elementType = normalizeConductorType(type.elementType, project);
-    return type;
-  }
-
-  if (type instanceof td.ConditionalType) {
-    type.checkType = normalizeConductorType(type.checkType, project);
-    type.extendsType = normalizeConductorType(type.extendsType, project);
-    type.trueType = normalizeConductorType(type.trueType, project);
-    type.falseType = normalizeConductorType(type.falseType, project);
-    return type;
-  }
-
-  if (type instanceof td.IndexedAccessType) {
-    type.objectType = normalizeConductorType(type.objectType, project);
-    type.indexType = normalizeConductorType(type.indexType, project);
-    return type;
-  }
-
-  if (type instanceof td.InferredType) {
-    if (type.constraint) {
-      type.constraint = normalizeConductorType(type.constraint, project);
-    }
-    return type;
-  }
-
-  if (type instanceof td.IntersectionType || type instanceof td.UnionType) {
-    type.types = type.types.map(each => normalizeConductorType(each, project));
-    return type;
-  }
-
-  if (type instanceof td.MappedType) {
-    type.parameterType = normalizeConductorType(type.parameterType, project);
-    type.templateType = normalizeConductorType(type.templateType, project);
-    if (type.nameType) {
-      type.nameType = normalizeConductorType(type.nameType, project);
-    }
-    return type;
-  }
-
-  if (type instanceof td.OptionalType || type instanceof td.RestType) {
-    type.elementType = normalizeConductorType(type.elementType, project);
-    return type;
-  }
-
-  if (type instanceof td.PredicateType) {
-    if (type.targetType) {
-      type.targetType = normalizeConductorType(type.targetType, project);
-    }
-    return type;
-  }
-
-  if (type instanceof td.ReflectionType) {
-    normalizeDeclaration(type.declaration, project);
-    return type;
-  }
-
-  if (type instanceof td.TupleType) {
-    type.elements = type.elements.map(each => normalizeConductorType(each, project));
-    return type;
-  }
-
-  if (type instanceof td.NamedTupleMember) {
-    type.element = normalizeConductorType(type.element, project);
-    return type;
-  }
-
-  if (type instanceof td.TypeOperatorType) {
-    type.target = normalizeConductorType(type.target, project);
-    return type;
-  }
-
-  if (type instanceof td.TemplateLiteralType) {
-    type.tail = type.tail.map(([tailType, text]) => [
-      normalizeConductorType(tailType, project),
-      text
-    ]);
-    return type;
-  }
-
-  return type;
-}
-
-/**
  * Identifies evaluator/conduit parameters that are implementation plumbing, not public API.
  */
-function isServiceParameter(parameter: td.ParameterReflection) {
+export function isServiceParameter(parameter: td.ParameterReflection) {
   if (!isReferenceType(parameter.type)) return false;
   return isConductorReference(parameter.type, SERVICE_PARAMETER_TYPES);
 }
 
 /**
- * Rewrites one call signature from Conductor-facing types to public module-facing types.
- */
-function normalizeSignature(signature: td.SignatureReflection, project: td.ProjectReflection) {
-  if (signature.type) {
-    project.removeTypeReflections(signature.type);
-    signature.type = normalizeConductorType(signature.type, project);
-  }
-
-  signature.parameters = signature.parameters
-    ?.filter(parameter => !isServiceParameter(parameter))
-    .map(parameter => {
-      if (parameter.type) {
-        project.removeTypeReflections(parameter.type);
-        parameter.type = normalizeConductorType(parameter.type, project);
-      }
-      return parameter;
-    });
-}
-
-/**
- * Applies signature/type normalization to a declaration and its accessors.
- */
-function normalizeDeclaration(declaration: td.DeclarationReflection, project: td.ProjectReflection) {
-  if (declaration.type) {
-    project.removeTypeReflections(declaration.type);
-    declaration.type = normalizeConductorType(declaration.type, project);
-  }
-
-  declaration.signatures?.forEach(signature => normalizeSignature(signature, project));
-  declaration.indexSignatures?.forEach(signature => normalizeSignature(signature, project));
-
-  if (declaration.getSignature) {
-    normalizeSignature(declaration.getSignature, project);
-  }
-
-  if (declaration.setSignature) {
-    normalizeSignature(declaration.setSignature, project);
-  }
-}
-
-/**
  * Detects migrated module plugin classes without depending on the concrete base-class name.
  */
-function isConductorPluginClass(reflection: td.DeclarationReflection) {
+export function isConductorPluginClass(reflection: td.DeclarationReflection) {
   if (reflection.kind !== td.ReflectionKind.Class) return false;
 
   const exportedNames = getExportedNames(reflection);
@@ -269,7 +94,7 @@ function isConductorPluginClass(reflection: td.DeclarationReflection) {
 /**
  * Extracts string literal values from the tuple/union TypeDoc emits for `exportedNames`.
  */
-function getStringLiterals(type: td.SomeType | undefined): string[] {
+export function getStringLiterals(type: td.SomeType | undefined): string[] {
   if (type instanceof td.TypeOperatorType) {
     return getStringLiterals(type.target);
   }
@@ -292,7 +117,7 @@ function getStringLiterals(type: td.SomeType | undefined): string[] {
 /**
  * Reads the authoritative list of public module exports from a plugin class.
  */
-function getExportedNames(plugin: td.DeclarationReflection) {
+export function getExportedNames(plugin: td.DeclarationReflection) {
   const exportedNames = plugin.children?.find(child => child.name === 'exportedNames');
   return new Set(getStringLiterals(exportedNames?.type));
 }
@@ -300,7 +125,7 @@ function getExportedNames(plugin: td.DeclarationReflection) {
 /**
  * Checks whether a type tree contains Conductor transport wrappers.
  */
-function hasConductorTransportType(type: td.SomeType | undefined): boolean {
+export function hasConductorTransportType(type: td.SomeType | undefined): boolean {
   if (!type) return false;
 
   if (type instanceof td.ReferenceType) {
@@ -333,7 +158,7 @@ function hasConductorTransportType(type: td.SomeType | undefined): boolean {
 /**
  * Determines whether a class method is both publicly exported and Conductor-shaped.
  */
-function isExportedConductorMethod(
+export function isExportedConductorMethod(
   child: td.DeclarationReflection,
   exportedNames: Set<string>
 ) {
@@ -343,14 +168,14 @@ function isExportedConductorMethod(
 
   return child.signatures?.some(signature => {
     return hasConductorTransportType(signature.type)
-      || signature.parameters?.some(parameter => hasConductorTransportType(parameter.type));
+            || signature.parameters?.some(parameter => hasConductorTransportType(parameter.type));
   }) ?? false;
 }
 
 /**
  * Prefers implementation JSDoc over wrapper-method JSDoc when both are available.
  */
-function getSignatureComment(
+export function getSignatureComment(
   implementationSignature: td.SignatureReflection | undefined,
   pluginSignature: td.SignatureReflection
 ) {
@@ -358,9 +183,9 @@ function getSignatureComment(
 }
 
 /**
- * Copies a method parameter onto a public function signature with normalized type/comment data.
+ * Copies a method parameter onto a public export function  signature with normalized type/comment data.
  */
-function cloneParameter(
+export function cloneParameter(
   parameter: td.ParameterReflection,
   parent: td.SignatureReflection,
   project: td.ProjectReflection,
@@ -376,16 +201,23 @@ function cloneParameter(
 }
 
 /**
- * Builds the public function signature from the plugin method and matching implementation docs.
+ * Copies visibility and modifier flags when replacing TypeDoc reflection nodes.
  */
-function copyPluginSignature(
+export function cloneFlags(source: td.Reflection, target: td.Reflection) {
+  target.flags.fromObject(source.flags.toObject());
+}
+
+/**
+ * Builds the public export function signature from the plugin method and matching implementation docs.
+ */
+export function copyPluginSignature(
   target: td.DeclarationReflection,
   pluginSignature: td.SignatureReflection,
   project: td.ProjectReflection,
   implementationSignature: td.SignatureReflection | undefined
 ) {
   const targetSignature = target.signatures?.[0]
-    ?? new td.SignatureReflection(target.name, td.ReflectionKind.CallSignature, target);
+        ?? new td.SignatureReflection(target.name, td.ReflectionKind.CallSignature, target);
 
   if (!target.signatures?.includes(targetSignature)) {
     target.signatures = [targetSignature];
@@ -406,19 +238,19 @@ function copyPluginSignature(
 }
 
 /**
- * Finds an existing top-level function reflection for a module export.
+ * Finds an existing top-level export function reflection for a module export.
  */
-function findPublicFunction(container: td.ContainerReflection, name: string) {
+export function findPublicFunction(container: td.ContainerReflection, name: string) {
   return container.children?.find(child => {
     return child.name === name
-      && child.kind === td.ReflectionKind.Function;
+            && child.kind === td.ReflectionKind.Function;
   });
 }
 
 /**
- * Creates a new top-level function reflection when the plugin method has no implementation twin.
+ * Creates a new top-level export function reflection when the plugin method has no implementation twin.
  */
-function createPublicFunction(
+export function createPublicFunction(
   container: td.ContainerReflection,
   name: string,
   project: td.ProjectReflection
@@ -432,7 +264,7 @@ function createPublicFunction(
 /**
  * Converts exported plugin methods into top-level functions and merges their public docs.
  */
-function promotePluginMethods(
+export function promotePluginMethods(
   container: td.ContainerReflection,
   plugin: td.DeclarationReflection,
   project: td.ProjectReflection
@@ -446,7 +278,7 @@ function promotePluginMethods(
       if (!pluginSignature) return;
 
       const publicFunction = findPublicFunction(container, method.name)
-        ?? createPublicFunction(container, method.name, project);
+                ?? createPublicFunction(container, method.name, project);
       const implementationSignature = publicFunction.signatures?.[0];
 
       copyPluginSignature(publicFunction, pluginSignature, project, implementationSignature);
@@ -456,7 +288,7 @@ function promotePluginMethods(
 /**
  * Preserves explicit `@group` tags, otherwise derives the default TypeDoc group title.
  */
-function groupNamesFor(reflection: td.DeclarationReflection | td.DocumentReflection) {
+export function groupNamesFor(reflection: td.DeclarationReflection | td.DocumentReflection) {
   const explicitGroups = reflection.comment?.blockTags
     ?.filter(tag => tag.tag === '@group')
     ?.map(tag => td.Comment.combineDisplayParts(tag.content).trim())
@@ -470,7 +302,7 @@ function groupNamesFor(reflection: td.DeclarationReflection | td.DocumentReflect
 /**
  * Reconciles TypeDoc groups after removing plugin classes and adding promoted functions.
  */
-function syncGroups(container: td.ContainerReflection) {
+export function syncGroups(container: td.ContainerReflection) {
   const children = container.childrenIncludingDocuments ?? [];
   const childSet = new Set(children);
   const groupedChildren = new Set<td.DeclarationReflection | td.DocumentReflection>();
@@ -504,40 +336,4 @@ function syncGroups(container: td.ContainerReflection) {
   }
 
   delete container.categories;
-}
-
-/**
- * Normalizes one container and recursively visits nested modules/namespaces.
- */
-function normalizeContainer(container: td.ContainerReflection, project: td.ProjectReflection): boolean {
-  let mutated = false;
-  const pluginClasses = container.children?.filter(isConductorPluginClass) ?? [];
-
-  pluginClasses.forEach(plugin => {
-    promotePluginMethods(container, plugin, project);
-    project.removeReflection(plugin);
-    mutated = true;
-  });
-
-  container.children?.forEach(child => {
-    normalizeDeclaration(child, project);
-
-    if (child.isContainer()) {
-      const childMutated = normalizeContainer(child, project);
-      mutated = mutated || childMutated;
-    }
-  });
-
-  if (mutated) {
-    syncGroups(container);
-  }
-
-  return mutated;
-}
-
-/**
- * Rewrites Conductor module implementation details into the public API surface.
- */
-export function normalizeConductorDocs(project: td.ProjectReflection) {
-  normalizeContainer(project, project);
 }

--- a/lib/buildtools/src/build/docs/index.ts
+++ b/lib/buildtools/src/build/docs/index.ts
@@ -3,6 +3,7 @@ import pathlib from 'path';
 import type { BuildResult, ResolvedBundle, ResultType } from '@sourceacademy/modules-repotools/types';
 import { mapAsync } from '@sourceacademy/modules-repotools/utils';
 import * as td from 'typedoc';
+import { normalizeConductorDocs } from './conductor.js';
 import { buildJson } from './json.js';
 import { initTypedocForHtml, initTypedocForJson } from './typedoc.js';
 
@@ -22,6 +23,8 @@ export async function buildSingleBundleDocs(bundle: ResolvedBundle, outDir: stri
       input: bundle
     };
   }
+
+  normalizeConductorDocs(project);
 
   // TypeDoc expects POSIX paths
   const directoryAsPosix = bundle.directory.replace(/\\/g, '/');
@@ -73,6 +76,8 @@ export async function buildHtml(bundles: Record<string, ResolvedBundle>, outDir:
       errors: ['Failed to generate reflections, check that there are no type errors across all bundles!']
     };
   }
+
+  normalizeConductorDocs(project);
 
   const htmlPath = pathlib.join(outDir, 'documentation');
   await app.generateDocs(project, htmlPath);

--- a/lib/buildtools/src/build/docs/index.ts
+++ b/lib/buildtools/src/build/docs/index.ts
@@ -3,7 +3,7 @@ import pathlib from 'path';
 import type { BuildResult, ResolvedBundle, ResultType } from '@sourceacademy/modules-repotools/types';
 import { mapAsync } from '@sourceacademy/modules-repotools/utils';
 import * as td from 'typedoc';
-import { normalizeConductorDocs } from './conductor.js';
+import { normalizeConductorDocs } from './conductor/index.js';
 import { buildJson } from './json.js';
 import { initTypedocForHtml, initTypedocForJson } from './typedoc.js';
 

--- a/lib/repotools/src/testing/__tests__/testing.test.ts
+++ b/lib/repotools/src/testing/__tests__/testing.test.ts
@@ -32,7 +32,7 @@ describe(testUtils.isTestDirectory, () => {
     mockedFsGlob.mockImplementationOnce(retValue ? async function* () {
       yield Promise.resolve('');
       return undefined;
-      // eslint-disable-next-line require-yield, @typescript-eslint/require-await
+      // eslint-disable-next-line @typescript-eslint/require-await
     } : async function* () {
       return undefined;
     });

--- a/lib/testplugin/package.json
+++ b/lib/testplugin/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@sourceacademy/modules-testplugin",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "description": "In-memory Conductor IDataHandler implementation for testing Source Academy modules",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@sourceacademy/conductor": "https://github.com/source-academy/conductor"
+  },
+  "devDependencies": {
+    "@sourceacademy/modules-buildtools": "workspace:^",
+    "eslint": "^9.35.0",
+    "typescript": "^6.0.2",
+    "vitest": "4.1.4"
+  },
+  "scripts": {
+    "build": "tsc --project ./tsconfig.prod.json",
+    "lint": "eslint src",
+    "postinstall": "yarn build",
+    "tsc": "tsc --project ./tsconfig.json",
+    "test": "buildtools test --project ."
+  }
+}

--- a/lib/testplugin/src/__tests__/fixtures.ts
+++ b/lib/testplugin/src/__tests__/fixtures.ts
@@ -1,0 +1,4 @@
+import { test as baseTest } from 'vitest';
+import { TestDataHandler } from '..';
+
+export const test = baseTest.extend('handler', () => new TestDataHandler());

--- a/lib/testplugin/src/__tests__/index.test.ts
+++ b/lib/testplugin/src/__tests__/index.test.ts
@@ -1,0 +1,99 @@
+import { DataType } from '@sourceacademy/conductor/types';
+import { describe, expect, it } from 'vitest';
+import {
+  TestDataHandler,
+  booleanValue,
+  callClosure,
+  closureFromFunction,
+  emptyListValue,
+  numberValue,
+  runAsyncGenerator,
+  stringValue
+} from '../index';
+
+describe(TestDataHandler, () => {
+  it('stores closures as normal JS functions and calls them', async () => {
+    const handler = new TestDataHandler();
+    const closure = await closureFromFunction(
+      handler,
+      {
+        args: [DataType.NUMBER] as const,
+        returnType: DataType.NUMBER
+      },
+      (x: unknown) => Number(x) + 1
+    );
+
+    expect(handler.closureMap.get(closure.value)).toEqual(expect.any(Function));
+    await expect(handler.closure_arity(closure)).resolves.toEqual(1);
+    await expect(handler.closure_is_vararg(closure)).resolves.toEqual(false);
+
+    const result = await callClosure(handler, closure, [numberValue(41)], DataType.NUMBER);
+    expect(result).toEqual(numberValue(42));
+  });
+
+  it('stores pairs as JS arrays in the pair map', async () => {
+    const handler = new TestDataHandler();
+    const pair = await handler.pair_make(numberValue(1), stringValue('tail'));
+
+    expect(handler.pairMap.get(pair.value)).toEqual([numberValue(1), stringValue('tail')]);
+    await expect(handler.pair_head(pair)).resolves.toEqual(numberValue(1));
+
+    await handler.pair_settail(pair, booleanValue(true));
+    await expect(handler.pair_tail(pair)).resolves.toEqual(booleanValue(true));
+    await expect(handler.pair_assert(pair, DataType.NUMBER, DataType.BOOLEAN)).resolves.toBeUndefined();
+  });
+
+  it('stores arrays as JS arrays in the array map and enforces element types', async () => {
+    const handler = new TestDataHandler();
+    const array = await handler.array_make(DataType.NUMBER, 3, numberValue(0));
+
+    expect(handler.arrayMap.get(array.value)).toEqual([
+      numberValue(0),
+      numberValue(0),
+      numberValue(0)
+    ]);
+
+    await handler.array_set(array, 1, numberValue(7));
+    await expect(handler.array_get(array, 1)).resolves.toEqual(numberValue(7));
+    await expect(handler.array_length(array)).resolves.toEqual(3);
+    await expect(handler.array_type(array)).resolves.toEqual(DataType.NUMBER);
+    await expect(handler.array_assert(array, DataType.NUMBER, 3)).resolves.toBeUndefined();
+    await expect(handler.array_set(array, 0, stringValue('wrong') as never)).rejects.toThrow(
+      'Array element expected NUMBER, got CONST_STRING.'
+    );
+  });
+
+  it('supports lists and accumulation using pair storage', async () => {
+    const handler = new TestDataHandler();
+    const xs = await handler.list(numberValue(1), numberValue(2), numberValue(3));
+    const add = await closureFromFunction(
+      handler,
+      {
+        args: [DataType.NUMBER, DataType.NUMBER] as const,
+        returnType: DataType.NUMBER
+      },
+      (x: unknown, y: unknown) => Number(x) + Number(y)
+    );
+
+    await expect(handler.is_list(xs)).resolves.toEqual(true);
+    await expect(handler.is_list(emptyListValue())).resolves.toEqual(true);
+    await expect(handler.list_to_vec(xs)).resolves.toEqual([
+      numberValue(1),
+      numberValue(2),
+      numberValue(3)
+    ]);
+    await expect(handler.length(xs)).resolves.toEqual(3);
+
+    const sum = await runAsyncGenerator(handler.accumulate(add, numberValue(0), xs, DataType.NUMBER));
+    expect(sum).toEqual(numberValue(6));
+  });
+
+  it('stores and updates opaque values', async () => {
+    const handler = new TestDataHandler();
+    const opaque = await handler.opaque_make({ value: 1 });
+
+    await expect(handler.opaque_get(opaque)).resolves.toEqual({ value: 1 });
+    await handler.opaque_update(opaque, { value: 2 });
+    await expect(handler.opaque_get(opaque)).resolves.toEqual({ value: 2 });
+  });
+});

--- a/lib/testplugin/src/__tests__/index.test.ts
+++ b/lib/testplugin/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import { DataType } from '@sourceacademy/conductor/types';
-import { describe, expect, it } from 'vitest';
+import { describe, expect } from 'vitest';
 import {
   TestDataHandler,
   booleanValue,
@@ -10,10 +10,10 @@ import {
   runAsyncGenerator,
   stringValue
 } from '../index';
+import { test } from './fixtures';
 
 describe(TestDataHandler, () => {
-  it('stores closures as normal JS functions and calls them', async () => {
-    const handler = new TestDataHandler();
+  test('stores closures as normal JS functions and calls them', async ({ handler }) => {
     const closure = await closureFromFunction(
       handler,
       {
@@ -31,8 +31,7 @@ describe(TestDataHandler, () => {
     expect(result).toEqual(numberValue(42));
   });
 
-  it('stores pairs as JS arrays in the pair map', async () => {
-    const handler = new TestDataHandler();
+  test('stores pairs as JS arrays in the pair map', async ({ handler }) => {
     const pair = await handler.pair_make(numberValue(1), stringValue('tail'));
 
     expect(handler.pairMap.get(pair.value)).toEqual([numberValue(1), stringValue('tail')]);
@@ -43,8 +42,7 @@ describe(TestDataHandler, () => {
     await expect(handler.pair_assert(pair, DataType.NUMBER, DataType.BOOLEAN)).resolves.toBeUndefined();
   });
 
-  it('stores arrays as JS arrays in the array map and enforces element types', async () => {
-    const handler = new TestDataHandler();
+  test('stores arrays as JS arrays in the array map and enforces element types', async ({ handler }) => {
     const array = await handler.array_make(DataType.NUMBER, 3, numberValue(0));
 
     expect(handler.arrayMap.get(array.value)).toEqual([
@@ -63,8 +61,7 @@ describe(TestDataHandler, () => {
     );
   });
 
-  it('supports lists and accumulation using pair storage', async () => {
-    const handler = new TestDataHandler();
+  test('supports lists and accumulation using pair storage', async ({ handler }) => {
     const xs = await handler.list(numberValue(1), numberValue(2), numberValue(3));
     const add = await closureFromFunction(
       handler,
@@ -88,12 +85,18 @@ describe(TestDataHandler, () => {
     expect(sum).toEqual(numberValue(6));
   });
 
-  it('stores and updates opaque values', async () => {
-    const handler = new TestDataHandler();
+  test('stores and updates opaque values', async ({ handler }) => {
     const opaque = await handler.opaque_make({ value: 1 });
 
     await expect(handler.opaque_get(opaque)).resolves.toEqual({ value: 1 });
     await handler.opaque_update(opaque, { value: 2 });
     await expect(handler.opaque_get(opaque)).resolves.toEqual({ value: 2 });
+  });
+
+  test('expect initial array to point to the same initial data', async ({ handler }) => {
+    const array = await handler.array_make(DataType.NUMBER, 3, numberValue(3));
+    const objValue = await handler.array_get(array, 0);
+    objValue.value = 4;
+    expect(await handler.array_get(array, 2)).toEqual(numberValue(4));
   });
 });

--- a/lib/testplugin/src/index.ts
+++ b/lib/testplugin/src/index.ts
@@ -1,0 +1,524 @@
+import type { IInterfacableEvaluator } from '@sourceacademy/conductor/runner';
+import {
+  DataType,
+  type ExternCallable,
+  type IFunctionSignature,
+  type TypedValue
+} from '@sourceacademy/conductor/types';
+
+type AnyTypedValue = TypedValue<DataType>;
+type PairEntry = [head: AnyTypedValue, tail: AnyTypedValue];
+type ClosureEntry = {
+  arity: number;
+  func: ExternCallable<any, any>;
+  returnType: DataType;
+  signature: IFunctionSignature<any, any>;
+};
+
+/**
+ * Drives a Conductor async generator to completion and returns its final value.
+ */
+export async function runAsyncGenerator<T>(generator: AsyncGenerator<unknown, T, unknown>): Promise<T> {
+  let result = await generator.next();
+  while (!result.done) {
+    result = await generator.next();
+  }
+
+  return result.value;
+}
+
+/**
+ * Constructs a Conductor number value.
+ */
+export function numberValue(value: number): TypedValue<DataType.NUMBER> {
+  return { type: DataType.NUMBER, value };
+}
+
+/**
+ * Constructs a Conductor boolean value.
+ */
+export function booleanValue(value: boolean): TypedValue<DataType.BOOLEAN> {
+  return { type: DataType.BOOLEAN, value };
+}
+
+/**
+ * Constructs a Conductor string value.
+ */
+export function stringValue(value: string): TypedValue<DataType.CONST_STRING> {
+  return { type: DataType.CONST_STRING, value };
+}
+
+/**
+ * Constructs a Conductor void value.
+ */
+export function voidValue(): TypedValue<DataType.VOID> {
+  return { type: DataType.VOID, value: undefined };
+}
+
+/**
+ * Constructs a Conductor empty-list value.
+ */
+export function emptyListValue(): TypedValue<DataType.EMPTY_LIST> {
+  return { type: DataType.EMPTY_LIST, value: null };
+}
+
+function isTypedValue(value: unknown): value is AnyTypedValue {
+  return typeof value === 'object'
+    && value !== null
+    && 'type' in value
+    && 'value' in value;
+}
+
+function typeName(type: DataType) {
+  return DataType[type] ?? String(type);
+}
+
+function matchesType(value: AnyTypedValue, expected: DataType | undefined) {
+  if (expected === undefined) return true;
+  if (expected === DataType.LIST) {
+    return value.type === DataType.PAIR || value.type === DataType.EMPTY_LIST;
+  }
+
+  return value.type === expected;
+}
+
+function assertTypedValue(value: AnyTypedValue, expected: DataType | undefined, context: string) {
+  if (!matchesType(value, expected)) {
+    throw new Error(`${context} expected ${typeName(expected!)}, got ${typeName(value.type)}.`);
+  }
+}
+
+function assertIndex(index: number, length: number) {
+  if (!Number.isInteger(index) || index < 0 || index >= length) {
+    throw new Error(`Array index ${index} is out of bounds for length ${length}.`);
+  }
+}
+
+function asPromise<T>(operation: () => T): Promise<T> {
+  try {
+    return Promise.resolve(operation());
+  } catch (error) {
+    return Promise.reject(error);
+  }
+}
+
+/**
+ * In-memory IDataHandler implementation for tests of Conductor modules.
+ */
+export class TestDataHandler implements IInterfacableEvaluator {
+  readonly hasDataInterface = true;
+  readonly closureMap = new Map<number, ExternCallable<any, any>>();
+  readonly pairMap = new Map<number, PairEntry>();
+  readonly arrayMap = new Map<number, AnyTypedValue[]>();
+  readonly opaqueMap = new Map<number, unknown>();
+
+  private nextIdentifier = 1;
+  private readonly arrayTypeMap = new Map<number, DataType>();
+  private readonly closureEntryMap = new Map<number, ClosureEntry>();
+
+  startEvaluator(_entryPoint: string) {
+    return Promise.resolve(undefined);
+  }
+
+  pair_make(head: AnyTypedValue, tail: AnyTypedValue): Promise<TypedValue<DataType.PAIR>> {
+    return asPromise(() => {
+      const id = this.allocateIdentifier();
+      this.pairMap.set(id, [head, tail]);
+      return { type: DataType.PAIR, value: id as TypedValue<DataType.PAIR>['value'] };
+    });
+  }
+
+  pair_head(p: TypedValue<DataType.PAIR>): Promise<AnyTypedValue> {
+    return asPromise(() => this.getPair(p)[0]);
+  }
+
+  pair_sethead(p: TypedValue<DataType.PAIR>, tv: AnyTypedValue): Promise<void> {
+    return asPromise(() => {
+      this.getPair(p)[0] = tv;
+    });
+  }
+
+  pair_tail(p: TypedValue<DataType.PAIR>): Promise<AnyTypedValue> {
+    return asPromise(() => this.getPair(p)[1]);
+  }
+
+  pair_settail(p: TypedValue<DataType.PAIR>, tv: AnyTypedValue): Promise<void> {
+    return asPromise(() => {
+      this.getPair(p)[1] = tv;
+    });
+  }
+
+  pair_assert(p: TypedValue<DataType.PAIR>, headType?: DataType, tailType?: DataType): Promise<void> {
+    return asPromise(() => {
+      const [head, tail] = this.getPair(p);
+      assertTypedValue(head, headType, 'Pair head');
+      assertTypedValue(tail, tailType, 'Pair tail');
+    });
+  }
+
+  array_make<T extends DataType>(
+    type: T,
+    len: number,
+    init?: TypedValue<NoInfer<T>>
+  ): Promise<TypedValue<DataType.ARRAY, NoInfer<T>>> {
+    return asPromise(() => {
+      const id = this.allocateIdentifier();
+      const initialValue = init ?? this.defaultValue(type);
+      this.arrayMap.set(id, Array.from({ length: len }, () => initialValue));
+      this.arrayTypeMap.set(id, type);
+      return {
+        type: DataType.ARRAY,
+        value: id as TypedValue<DataType.ARRAY, NoInfer<T>>['value']
+      };
+    });
+  }
+
+  array_length(a: TypedValue<DataType.ARRAY>): Promise<number> {
+    return asPromise(() => this.getArray(a).length);
+  }
+
+  array_get(a: TypedValue<DataType.ARRAY, DataType.VOID>, idx: number): Promise<AnyTypedValue>;
+  array_get<T extends DataType>(
+    a: TypedValue<DataType.ARRAY, T>,
+    idx: number
+  ): Promise<TypedValue<NoInfer<T>>>;
+  array_get<T extends DataType>(
+    a: TypedValue<DataType.ARRAY, T>,
+    idx: number
+  ): Promise<TypedValue<NoInfer<T>>> {
+    return asPromise(() => {
+      const array = this.getArray(a);
+      assertIndex(idx, array.length);
+      return array[idx] as TypedValue<NoInfer<T>>;
+    });
+  }
+
+  array_type<T extends DataType>(a: TypedValue<DataType.ARRAY, T>): Promise<NoInfer<T>> {
+    return asPromise(() => this.getArrayType(a) as NoInfer<T>);
+  }
+
+  array_set(a: TypedValue<DataType.ARRAY, DataType.VOID>, idx: number, tv: AnyTypedValue): Promise<void>;
+  array_set<T extends DataType>(
+    a: TypedValue<DataType.ARRAY, T>,
+    idx: number,
+    tv: TypedValue<NoInfer<T>>
+  ): Promise<void>;
+  array_set<T extends DataType>(
+    a: TypedValue<DataType.ARRAY, T>,
+    idx: number,
+    tv: AnyTypedValue
+  ): Promise<void> {
+    return asPromise(() => {
+      const array = this.getArray(a);
+      const arrayType = this.getArrayType(a);
+      assertIndex(idx, array.length);
+
+      if (arrayType !== DataType.VOID) {
+        assertTypedValue(tv, arrayType, 'Array element');
+      }
+
+      array[idx] = tv;
+    });
+  }
+
+  array_assert<T extends DataType>(
+    a: TypedValue<DataType.ARRAY>,
+    type?: T,
+    length?: number
+  ): Promise<void> {
+    return asPromise(() => {
+      const array = this.getArray(a);
+      const arrayType = this.getArrayType(a);
+
+      if (type !== undefined && arrayType !== type) {
+        throw new Error(`Array expected element type ${typeName(type)}, got ${typeName(arrayType)}.`);
+      }
+
+      if (length !== undefined && array.length !== length) {
+        throw new Error(`Array expected length ${length}, got ${array.length}.`);
+      }
+    });
+  }
+
+  closure_make<const Arg extends readonly DataType[], const Ret extends DataType>(
+    sig: IFunctionSignature<Arg, Ret>,
+    func: ExternCallable<Arg, Ret>,
+    _dependsOn?: (AnyTypedValue | null)[]
+  ): Promise<TypedValue<DataType.CLOSURE, Ret>> {
+    return asPromise(() => {
+      const id = this.allocateIdentifier();
+      this.closureMap.set(id, func);
+      this.closureEntryMap.set(id, {
+        arity: sig.args.length,
+        func,
+        returnType: sig.returnType,
+        signature: sig
+      });
+      return { type: DataType.CLOSURE, value: id as TypedValue<DataType.CLOSURE, Ret>['value'] };
+    });
+  }
+
+  closure_is_vararg(_c: TypedValue<DataType.CLOSURE>): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
+  closure_arity(c: TypedValue<DataType.CLOSURE>): Promise<number> {
+    return asPromise(() => this.getClosureEntry(c).arity);
+  }
+
+  async *closure_call<T extends DataType>(
+    c: TypedValue<DataType.CLOSURE, T>,
+    args: AnyTypedValue[],
+    returnType: T
+  ): AsyncGenerator<void, TypedValue<NoInfer<T>>, undefined> {
+    const result = yield* this.closure_call_unchecked(c, args);
+    assertTypedValue(result, returnType, 'Closure return value');
+    return result as TypedValue<NoInfer<T>>;
+  }
+
+  async *closure_call_unchecked<T extends DataType>(
+    c: TypedValue<DataType.CLOSURE, T>,
+    args: AnyTypedValue[]
+  ): AsyncGenerator<void, TypedValue<NoInfer<T>>, undefined> {
+    const closure = this.getClosureEntry(c);
+    const result = yield* closure.func(...args as Parameters<typeof closure.func>);
+    return result as TypedValue<NoInfer<T>>;
+  }
+
+  async closure_arity_assert(c: TypedValue<DataType.CLOSURE>, arity: number): Promise<void> {
+    const actualArity = await this.closure_arity(c);
+    if (actualArity !== arity) {
+      throw new Error(`Closure expected arity ${arity}, got ${actualArity}.`);
+    }
+  }
+
+  opaque_make(value: unknown, _immutable?: boolean): Promise<TypedValue<DataType.OPAQUE>> {
+    return asPromise(() => {
+      const id = this.allocateIdentifier();
+      this.opaqueMap.set(id, value);
+      return { type: DataType.OPAQUE, value: id as TypedValue<DataType.OPAQUE>['value'] };
+    });
+  }
+
+  opaque_get(o: TypedValue<DataType.OPAQUE>): Promise<unknown> {
+    return asPromise(() => this.getOpaque(o));
+  }
+
+  opaque_update(o: TypedValue<DataType.OPAQUE>, value: unknown): Promise<void> {
+    return asPromise(() => {
+      this.getOpaque(o);
+      this.opaqueMap.set(o.value, value);
+    });
+  }
+
+  tie(_dependent: AnyTypedValue, _dependee: AnyTypedValue | null): Promise<void> {
+    return Promise.resolve();
+  }
+
+  untie(_dependent: AnyTypedValue, _dependee: AnyTypedValue | null): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async list(...elements: AnyTypedValue[]): Promise<TypedValue<DataType.LIST>> {
+    let result: AnyTypedValue = emptyListValue();
+    for (let i = elements.length - 1; i >= 0; i -= 1) {
+      result = await this.pair_make(elements[i], result);
+    }
+
+    return result as TypedValue<DataType.LIST>;
+  }
+
+  async is_list(xs: TypedValue<DataType.LIST>): Promise<boolean> {
+    try {
+      await this.list_to_vec(xs);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  list_to_vec(xs: TypedValue<DataType.LIST>): Promise<AnyTypedValue[]> {
+    return asPromise(() => {
+      const result: AnyTypedValue[] = [];
+      let current = xs as AnyTypedValue;
+
+      while (current.type !== DataType.EMPTY_LIST) {
+        if (current.type !== DataType.PAIR) {
+          throw new Error(`Expected list, got ${typeName(current.type)}.`);
+        }
+
+        const [head, tail] = this.getPair(current);
+        result.push(head);
+        current = tail;
+      }
+
+      return result;
+    });
+  }
+
+  async *accumulate<T extends Exclude<DataType, DataType.VOID>>(
+    op: TypedValue<DataType.CLOSURE, T>,
+    initial: TypedValue<T>,
+    sequence: TypedValue<DataType.LIST>,
+    resultType: T
+  ): AsyncGenerator<void, TypedValue<T>, undefined> {
+    const elements = await this.list_to_vec(sequence);
+    let result = initial;
+
+    for (let i = elements.length - 1; i >= 0; i -= 1) {
+      result = yield* this.closure_call(op, [elements[i], result], resultType);
+    }
+
+    return result;
+  }
+
+  async length(xs: TypedValue<DataType.LIST>): Promise<number> {
+    return (await this.list_to_vec(xs)).length;
+  }
+
+  /**
+   * Converts a typed value into the raw JS value stored by this handler.
+   */
+  toNative(value: AnyTypedValue): unknown {
+    switch (value.type) {
+      case DataType.VOID:
+      case DataType.BOOLEAN:
+      case DataType.NUMBER:
+      case DataType.CONST_STRING:
+      case DataType.EMPTY_LIST:
+        return value.value;
+      case DataType.PAIR:
+        return this.getPair(value);
+      case DataType.ARRAY:
+        return this.getArray(value);
+      case DataType.CLOSURE:
+        return this.getClosureEntry(value).func;
+      case DataType.OPAQUE:
+        return this.getOpaque(value);
+      default:
+        return value;
+    }
+  }
+
+  /**
+   * Converts a raw JS value or existing typed value into a Conductor typed value.
+   */
+  toTyped<T extends DataType>(type: T, value: unknown): TypedValue<T> {
+    if (isTypedValue(value)) {
+      assertTypedValue(value, type, 'Typed value');
+      return value as TypedValue<T>;
+    }
+
+    switch (type) {
+      case DataType.VOID:
+        return voidValue() as TypedValue<T>;
+      case DataType.BOOLEAN:
+        return booleanValue(Boolean(value)) as TypedValue<T>;
+      case DataType.NUMBER:
+        return numberValue(Number(value)) as TypedValue<T>;
+      case DataType.CONST_STRING:
+        return stringValue(String(value)) as TypedValue<T>;
+      case DataType.EMPTY_LIST:
+        return emptyListValue() as TypedValue<T>;
+      default:
+        throw new Error(`Cannot automatically convert JS value to ${typeName(type)}.`);
+    }
+  }
+
+  private allocateIdentifier() {
+    const id = this.nextIdentifier;
+    this.nextIdentifier += 1;
+    return id;
+  }
+
+  private defaultValue<T extends DataType>(type: T): TypedValue<T> {
+    switch (type) {
+      case DataType.VOID:
+        return voidValue() as TypedValue<T>;
+      case DataType.BOOLEAN:
+        return booleanValue(false) as TypedValue<T>;
+      case DataType.NUMBER:
+        return numberValue(0) as TypedValue<T>;
+      case DataType.CONST_STRING:
+        return stringValue('') as TypedValue<T>;
+      case DataType.EMPTY_LIST:
+        return emptyListValue() as TypedValue<T>;
+      default:
+        throw new Error(`Array initial value is required for ${typeName(type)} arrays.`);
+    }
+  }
+
+  private getPair(pair: TypedValue<DataType.PAIR>) {
+    const entry = this.pairMap.get(pair.value);
+    if (!entry) {
+      throw new Error(`Unknown pair identifier ${pair.value}.`);
+    }
+
+    return entry;
+  }
+
+  private getArray(array: TypedValue<DataType.ARRAY>) {
+    const entry = this.arrayMap.get(array.value);
+    if (!entry) {
+      throw new Error(`Unknown array identifier ${array.value}.`);
+    }
+
+    return entry;
+  }
+
+  private getArrayType(array: TypedValue<DataType.ARRAY>) {
+    const type = this.arrayTypeMap.get(array.value);
+    if (type === undefined) {
+      throw new Error(`Unknown array identifier ${array.value}.`);
+    }
+
+    return type;
+  }
+
+  private getClosureEntry(closure: TypedValue<DataType.CLOSURE>) {
+    const entry = this.closureEntryMap.get(closure.value);
+    if (!entry) {
+      throw new Error(`Unknown closure identifier ${closure.value}.`);
+    }
+
+    return entry;
+  }
+
+  private getOpaque(opaque: TypedValue<DataType.OPAQUE>) {
+    if (!this.opaqueMap.has(opaque.value)) {
+      throw new Error(`Unknown opaque identifier ${opaque.value}.`);
+    }
+
+    return this.opaqueMap.get(opaque.value);
+  }
+}
+
+/**
+ * Wraps a normal JS function as a Conductor closure stored in the test handler.
+ */
+export async function closureFromFunction<const Arg extends readonly DataType[], const Ret extends DataType>(
+  handler: TestDataHandler,
+  signature: IFunctionSignature<Arg, Ret>,
+  func: (...args: unknown[]) => unknown | Promise<unknown>
+): Promise<TypedValue<DataType.CLOSURE, Ret>> {
+  return handler.closure_make(signature, async function* (...args: AnyTypedValue[]) {
+    const result = await func(...args.map(arg => handler.toNative(arg)));
+    return handler.toTyped(signature.returnType, result);
+  } as ExternCallable<Arg, Ret>);
+}
+
+/**
+ * Calls a closure and checks that the returned value has the expected type.
+ */
+export async function callClosure<T extends DataType>(
+  handler: TestDataHandler,
+  closure: TypedValue<DataType.CLOSURE, T>,
+  args: AnyTypedValue[],
+  returnType?: T
+): Promise<TypedValue<T>> {
+  return runAsyncGenerator(
+    returnType === undefined
+      ? handler.closure_call_unchecked(closure, args)
+      : handler.closure_call(closure, args, returnType)
+  );
+}

--- a/lib/testplugin/tsconfig.json
+++ b/lib/testplugin/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  },
+  "extends": "../tsconfig.json",
+  "include": ["./src"]
+}

--- a/lib/testplugin/tsconfig.prod.json
+++ b/lib/testplugin/tsconfig.prod.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "removeComments": false
+  },
+  "extends": "./tsconfig.json",
+  "exclude": ["**/__tests__"]
+}

--- a/lib/testplugin/vitest.config.ts
+++ b/lib/testplugin/vitest.config.ts
@@ -1,0 +1,17 @@
+import type { ViteUserConfig } from 'vitest/config';
+import rootConfig from '../../vitest.config.js';
+
+const config: ViteUserConfig = {
+  ...rootConfig,
+  test: {
+    ...rootConfig.test,
+    name: 'Modules Test Plugin',
+    environment: 'node',
+    root: import.meta.dirname,
+    include: ['**/__tests__/**/*.test.ts'],
+    watch: false,
+    projects: undefined
+  }
+};
+
+export default config;

--- a/src/bundles/repeat/package.json
+++ b/src/bundles/repeat/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "devDependencies": {
+    "@sourceacademy/conductor": "https://github.com/source-academy/conductor",
     "@sourceacademy/modules-buildtools": "workspace:^",
     "typescript": "^6.0.2"
   },

--- a/src/bundles/repeat/package.json
+++ b/src/bundles/repeat/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "@sourceacademy/conductor": "https://github.com/source-academy/conductor",
     "@sourceacademy/modules-buildtools": "workspace:^",
+    "@sourceacademy/modules-testplugin": "workspace:^",
     "typescript": "^6.0.2"
   },
   "type": "module",

--- a/src/bundles/repeat/src/__tests__/index.test.ts
+++ b/src/bundles/repeat/src/__tests__/index.test.ts
@@ -1,20 +1,61 @@
-// TODO: re-enable test once infrastructure is set up
-// import { expect, test } from 'vitest';
+import { DataType, type TypedValue } from '@sourceacademy/conductor/types';
+import {
+  TestDataHandler,
+  callClosure,
+  closureFromFunction,
+  numberValue,
+  runAsyncGenerator
+} from '@sourceacademy/modules-testplugin';
+import { describe, expect, it } from 'vitest';
+import { repeat, thrice, twice } from '../functions';
 
-// import { repeat, thrice, twice } from '../functions';
+async function makePlusOne(handler: TestDataHandler) {
+  return closureFromFunction(
+    handler,
+    {
+      args: [DataType.NUMBER] as const,
+      returnType: DataType.NUMBER
+    },
+    x => Number(x) + 1
+  );
+}
 
-// // Test functions
-// test('repeat works correctly and repeats function n times', () => {
-//   expect(repeat((x: number) => x + 1, 5)(1))
-//     .toBe(6);
-// });
+async function callNumberClosure(
+  handler: TestDataHandler,
+  closure: TypedValue<DataType.CLOSURE>,
+  value: number
+) {
+  const result = await callClosure(
+    handler,
+    closure,
+    [numberValue(value)],
+    DataType.NUMBER
+  );
+  return result.value;
+}
 
-// test('twice works correctly and repeats function twice', () => {
-//   expect(twice((x: number) => x + 1)(1))
-//     .toBe(3);
-// });
+describe(repeat, () => {
+  it('applies a closure n times', async () => {
+    const handler = new TestDataHandler();
+    const plusOne = await makePlusOne(handler);
+    const repeated = await runAsyncGenerator(repeat(handler, plusOne, numberValue(5)));
 
-// test('thrice works correctly and repeats function thrice', () => {
-//   expect(thrice((x: number) => x + 1)(1))
-//     .toBe(4);
-// });
+    await expect(callNumberClosure(handler, repeated, 1)).resolves.toEqual(6);
+  });
+
+  it('applies a closure twice', async () => {
+    const handler = new TestDataHandler();
+    const plusOne = await makePlusOne(handler);
+    const repeated = await runAsyncGenerator(twice(handler, plusOne));
+
+    await expect(callNumberClosure(handler, repeated, 1)).resolves.toEqual(3);
+  });
+
+  it('applies a closure thrice', async () => {
+    const handler = new TestDataHandler();
+    const plusOne = await makePlusOne(handler);
+    const repeated = await runAsyncGenerator(thrice(handler, plusOne));
+
+    await expect(callNumberClosure(handler, repeated, 1)).resolves.toEqual(4);
+  });
+});

--- a/src/bundles/repeat/src/__tests__/index.test.ts
+++ b/src/bundles/repeat/src/__tests__/index.test.ts
@@ -1,19 +1,20 @@
-import { expect, test } from 'vitest';
+// TODO: re-enable test once infrastructure is set up
+// import { expect, test } from 'vitest';
 
-import { repeat, thrice, twice } from '../functions';
+// import { repeat, thrice, twice } from '../functions';
 
-// Test functions
-test('repeat works correctly and repeats function n times', () => {
-  expect(repeat((x: number) => x + 1, 5)(1))
-    .toBe(6);
-});
+// // Test functions
+// test('repeat works correctly and repeats function n times', () => {
+//   expect(repeat((x: number) => x + 1, 5)(1))
+//     .toBe(6);
+// });
 
-test('twice works correctly and repeats function twice', () => {
-  expect(twice((x: number) => x + 1)(1))
-    .toBe(3);
-});
+// test('twice works correctly and repeats function twice', () => {
+//   expect(twice((x: number) => x + 1)(1))
+//     .toBe(3);
+// });
 
-test('thrice works correctly and repeats function thrice', () => {
-  expect(thrice((x: number) => x + 1)(1))
-    .toBe(4);
-});
+// test('thrice works correctly and repeats function thrice', () => {
+//   expect(thrice((x: number) => x + 1)(1))
+//     .toBe(4);
+// });

--- a/src/bundles/repeat/src/functions.ts
+++ b/src/bundles/repeat/src/functions.ts
@@ -3,6 +3,7 @@
  * @module repeat
  */
 
+import { DataType, type IDataHandler, type TypedValue } from '@sourceacademy/conductor/types';
 /**
  * Returns a new function which when applied to an argument, has the same effect
  * as applying the specified function to the same argument n times.
@@ -15,8 +16,27 @@
  * @param n the number of times to repeat the function
  * @returns the new function that has the same effect as func repeated n times
  */
-export function repeat(func: Function, n: number): Function {
-  return n === 0 ? (x: any) => x : (x: any) => func(repeat(func, n - 1)(x));
+export async function* repeat(evaluator: IDataHandler, func: TypedValue<DataType.CLOSURE>, n: TypedValue<DataType.NUMBER>): AsyncGenerator<void, TypedValue<DataType.CLOSURE>, unknown> {
+  async function* identity(x: any) {
+    return x;
+  }
+  async function* composition(x: any) {
+    const recursiveFunc = yield* repeat(evaluator, func, { type: DataType.NUMBER, value: n.value - 1 });
+    return yield* evaluator.closure_call_unchecked(func, [
+      yield* evaluator.closure_call_unchecked(
+        recursiveFunc,
+        [x]
+      )]);
+  }
+
+  return await evaluator.closure_make(
+    {
+      name: 'function',
+      args: [DataType.VOID] as const,
+      returnType: DataType.VOID
+    },
+    n.value === 0 ? identity : composition
+  );
 }
 
 /**
@@ -30,8 +50,8 @@ export function repeat(func: Function, n: number): Function {
  * @param func the function to be repeated
  * @returns the new function that has the same effect as `(x => func(func(x)))`
  */
-export function twice(func: Function): Function {
-  return repeat(func, 2);
+export async function* twice(evaluator: IDataHandler, func: TypedValue<DataType.CLOSURE>): AsyncGenerator<void, TypedValue<DataType.CLOSURE>, unknown> {
+  return yield* repeat(evaluator, func, { type: DataType.NUMBER, value: 2 });
 }
 
 /**
@@ -45,6 +65,6 @@ export function twice(func: Function): Function {
  * @param func the function to be repeated
  * @returns the new function that has the same effect as `(x => func(func(func(x))))`
  */
-export function thrice(func: Function): Function {
-  return repeat(func, 3);
+export async function* thrice(evaluator: IDataHandler, func: TypedValue<DataType.CLOSURE>): AsyncGenerator<void, TypedValue<DataType.CLOSURE>, unknown> {
+  return yield* repeat(evaluator, func, { type: DataType.NUMBER, value: 3 });
 }

--- a/src/bundles/repeat/src/functions.ts
+++ b/src/bundles/repeat/src/functions.ts
@@ -4,18 +4,7 @@
  */
 
 import { DataType, type IDataHandler, type TypedValue } from '@sourceacademy/conductor/types';
-/**
- * Returns a new function which when applied to an argument, has the same effect
- * as applying the specified function to the same argument n times.
- * @example
- * ```
- * const plusTen = repeat(x => x + 2, 5);
- * plusTen(0); // Returns 10
- * ```
- * @param func the function to be repeated
- * @param n the number of times to repeat the function
- * @returns the new function that has the same effect as func repeated n times
- */
+
 export async function* repeat(evaluator: IDataHandler, func: TypedValue<DataType.CLOSURE>, n: TypedValue<DataType.NUMBER>): AsyncGenerator<void, TypedValue<DataType.CLOSURE>, unknown> {
   async function* identity(x: any) {
     return x;
@@ -39,32 +28,10 @@ export async function* repeat(evaluator: IDataHandler, func: TypedValue<DataType
   );
 }
 
-/**
- * Returns a new function which when applied to an argument, has the same effect
- * as applying the specified function to the same argument 2 times.
- * @example
- * ```
- * const plusTwo = twice(x => x + 1);
- * plusTwo(2); // Returns 4
- * ```
- * @param func the function to be repeated
- * @returns the new function that has the same effect as `(x => func(func(x)))`
- */
 export async function* twice(evaluator: IDataHandler, func: TypedValue<DataType.CLOSURE>): AsyncGenerator<void, TypedValue<DataType.CLOSURE>, unknown> {
   return yield* repeat(evaluator, func, { type: DataType.NUMBER, value: 2 });
 }
 
-/**
- * Returns a new function which when applied to an argument, has the same effect
- * as applying the specified function to the same argument 3 times.
- * @example
- * ```
- * const plusNine = thrice(x => x + 3);
- * plusNine(0); // Returns 9
- * ```
- * @param func the function to be repeated
- * @returns the new function that has the same effect as `(x => func(func(func(x))))`
- */
 export async function* thrice(evaluator: IDataHandler, func: TypedValue<DataType.CLOSURE>): AsyncGenerator<void, TypedValue<DataType.CLOSURE>, unknown> {
   return yield* repeat(evaluator, func, { type: DataType.NUMBER, value: 3 });
 }

--- a/src/bundles/repeat/src/index.ts
+++ b/src/bundles/repeat/src/index.ts
@@ -19,16 +19,50 @@ export default class RepeatModulePlugin extends BaseModulePlugin {
   constructor(conduit: IConduit, channels: IChannel<any>[], evaluator: IInterfacableEvaluator) {
     super(conduit, channels, evaluator);
   }
-
+  /**
+   * Returns a new function which when applied to an argument, has the same effect
+   * as applying the specified function to the same argument n times.
+   * @example
+   * ```
+   * const plusTen = repeat(x => x + 2, 5);
+   * plusTen(0); // Returns 10
+   * ```
+   * @param func the function to be repeated
+   * @param n the number of times to repeat the function
+   * @returns the new function that has the same effect as func repeated n times
+   */
   @moduleMethod([DataType.CLOSURE, DataType.NUMBER], DataType.CLOSURE)
   async* repeat(func: TypedValue<DataType.CLOSURE>, n: TypedValue<DataType.NUMBER>): AsyncGenerator<void, TypedValue<DataType.CLOSURE>, unknown> {
     return yield* repeat_func(this.evaluator, func, n);
   }
 
+  /**
+   * Returns a new function which when applied to an argument, has the same effect
+   * as applying the specified function to the same argument 2 times.
+   * @example
+   * ```
+   * const plusTwo = twice(x => x + 1);
+   * plusTwo(2); // Returns 4
+   * ```
+   * @param func the function to be repeated
+   * @returns the new function that has the same effect as `(x => func(func(x)))`
+   */
   @moduleMethod([DataType.CLOSURE], DataType.CLOSURE)
   async* twice(func: TypedValue<DataType.CLOSURE>): AsyncGenerator<void, TypedValue<DataType.CLOSURE>, unknown> {
     return yield* twice_func(this.evaluator, func);
   }
+
+  /**
+   * Returns a new function which when applied to an argument, has the same effect
+   * as applying the specified function to the same argument 3 times.
+   * @example
+   * ```
+   * const plusNine = thrice(x => x + 3);
+   * plusNine(0); // Returns 9
+   * ```
+   * @param func the function to be repeated
+   * @returns the new function that has the same effect as `(x => func(func(func(x))))`
+   */
   @moduleMethod([DataType.CLOSURE], DataType.CLOSURE)
   async* thrice(func: TypedValue<DataType.CLOSURE>): AsyncGenerator<void, TypedValue<DataType.CLOSURE>, unknown> {
     return yield* thrice_func(this.evaluator, func);

--- a/src/bundles/repeat/src/index.ts
+++ b/src/bundles/repeat/src/index.ts
@@ -5,4 +5,32 @@
  * @module repeat
  */
 
-export { repeat, twice, thrice } from './functions';
+import type { IChannel, IConduit } from '@sourceacademy/conductor/conduit';
+import { BaseModulePlugin, moduleMethod } from '@sourceacademy/conductor/module';
+import type { IInterfacableEvaluator } from '@sourceacademy/conductor/runner';
+import { DataType, type TypedValue } from '@sourceacademy/conductor/types';
+
+import { repeat as repeat_func, thrice as thrice_func, twice as twice_func } from './functions';
+
+export default class RepeatModulePlugin extends BaseModulePlugin {
+  id = 'repeat';
+  exportedNames = ['repeat', 'twice', 'thrice'] as const;
+  static channelAttach = [];
+  constructor(conduit: IConduit, channels: IChannel<any>[], evaluator: IInterfacableEvaluator) {
+    super(conduit, channels, evaluator);
+  }
+
+  @moduleMethod([DataType.CLOSURE, DataType.NUMBER], DataType.CLOSURE)
+  async* repeat(func: TypedValue<DataType.CLOSURE>, n: TypedValue<DataType.NUMBER>): AsyncGenerator<void, TypedValue<DataType.CLOSURE>, unknown> {
+    return yield* repeat_func(this.evaluator, func, n);
+  }
+
+  @moduleMethod([DataType.CLOSURE], DataType.CLOSURE)
+  async* twice(func: TypedValue<DataType.CLOSURE>): AsyncGenerator<void, TypedValue<DataType.CLOSURE>, unknown> {
+    return yield* twice_func(this.evaluator, func);
+  }
+  @moduleMethod([DataType.CLOSURE], DataType.CLOSURE)
+  async* thrice(func: TypedValue<DataType.CLOSURE>): AsyncGenerator<void, TypedValue<DataType.CLOSURE>, unknown> {
+    return yield* thrice_func(this.evaluator, func);
+  }
+}

--- a/src/bundles/repeat/tsconfig.json
+++ b/src/bundles/repeat/tsconfig.json
@@ -5,7 +5,9 @@
   ],
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "experimentalDecorators": false,
+    "emitDecoratorMetadata": false
   },
   "typedocOptions": {
     "name": "repeat"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3994,6 +3994,7 @@ __metadata:
   dependencies:
     "@sourceacademy/conductor": "https://github.com/source-academy/conductor"
     "@sourceacademy/modules-buildtools": "workspace:^"
+    "@sourceacademy/modules-testplugin": "workspace:^"
     typescript: "npm:^6.0.2"
   languageName: unknown
   linkType: soft
@@ -4329,6 +4330,18 @@ __metadata:
   peerDependencies:
     "@vitejs/plugin-react": "*"
     vitest-browser-react: "*"
+  languageName: unknown
+  linkType: soft
+
+"@sourceacademy/modules-testplugin@workspace:^, @sourceacademy/modules-testplugin@workspace:lib/testplugin":
+  version: 0.0.0-use.local
+  resolution: "@sourceacademy/modules-testplugin@workspace:lib/testplugin"
+  dependencies:
+    "@sourceacademy/conductor": "https://github.com/source-academy/conductor"
+    "@sourceacademy/modules-buildtools": "workspace:^"
+    eslint: "npm:^9.35.0"
+    typescript: "npm:^6.0.2"
+    vitest: "npm:4.1.4"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3992,6 +3992,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sourceacademy/bundle-repeat@workspace:src/bundles/repeat"
   dependencies:
+    "@sourceacademy/conductor": "https://github.com/source-academy/conductor"
     "@sourceacademy/modules-buildtools": "workspace:^"
     typescript: "npm:^6.0.2"
   languageName: unknown
@@ -4122,6 +4123,13 @@ __metadata:
     typescript: "npm:^6.0.2"
   languageName: unknown
   linkType: soft
+
+"@sourceacademy/conductor@https://github.com/source-academy/conductor":
+  version: 0.5.0
+  resolution: "@sourceacademy/conductor@https://github.com/source-academy/conductor.git#commit=8bda154466fd1e8c97ac0fff01f42bc7d3b196df"
+  checksum: 10c0/acf42d7cb4d036f2b9a2fe2a0a2da3a5670c0fef2cf705a3a367768854413bcbbdb1e6d9ecfd810f9024f60c52ae0973332c0be14ce2fde1cb6598b0cf202a5b
+  languageName: node
+  linkType: hard
 
 "@sourceacademy/lint-plugin@workspace:^, @sourceacademy/lint-plugin@workspace:lib/lintplugin":
   version: 0.0.0-use.local


### PR DESCRIPTION
# Description

This PR kickstarts the initial migration of the modules to the Conductor framework. It 
- ports the Repeat module to support the language and evaluator agnostic [Conductor module interface](https://github.com/source-academy/conductor#module-interface). 
- implements Typedoc reflection mappings to properly convert the new module plugin into the original documentation format
- creates a common testing plugin (`@sourceacademy/modules-testplugin`) for Conductor testing utilities (including a sample native evaluator)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Running `yarn build:libs && yarn build:docs` and verifying that the documentation has been unaffected
- [x] Unit tests for `src/bundles/repeat`
- [x] Unit tests for `lib/testplugin`
- [x] Unit tests for `lib/buildtools/src/build/docs/conductor.ts`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
