### PR TITLE
Fix tsc errors post-dependency update

### DIFF
--- a/.github/actions/package.json
+++ b/.github/actions/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@sourceacademy/modules-repotools": "workspace:^",
     "@types/node": "^24.0.0",
-    "typescript": "^6.0.2",
+    "typescript": "catalog:",
     "vitest": "catalog:"
   },
   "dependencies": {

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -25,3 +25,4 @@ catalog:
   '@vitest/coverage-v8': 4.1.9
   '@vitest/ui': 4.1.9
   '@vitest/eslint-plugin': ^1.6.20
+  typescript: ^6.0.3

--- a/devserver/package.json
+++ b/devserver/package.json
@@ -33,7 +33,7 @@
     "eslint": "^9.35.0",
     "playwright": "^1.55.1",
     "sass": "^1.85.0",
-    "typescript": "^6.0.2",
+    "typescript": "catalog:",
     "vitest": "catalog:",
     "vitest-browser-react": "^2.1.0"
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -30,6 +30,6 @@
   "devDependencies": {
     "@types/node": "^24.0.0",
     "cspell": "^10.0.0",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   }
 }

--- a/lib/buildtools/package.json
+++ b/lib/buildtools/package.json
@@ -8,7 +8,7 @@
     "@types/estree": "^1.0.0",
     "@types/http-server": "^0.12.4",
     "@types/node": "^24.0.0",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "exports": null,
   "bin": {

--- a/lib/lintplugin/package.json
+++ b/lib/lintplugin/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "globals": "^17.0.0",
     "js-slang": "catalog:",
-    "typescript": "^6.0.2",
+    "typescript": "catalog:",
     "typescript-eslint": "^8.58.2"
   },
   "scripts": {

--- a/lib/lintplugin/package.json
+++ b/lib/lintplugin/package.json
@@ -14,7 +14,7 @@
     "eslint": "^9.35.0"
   },
   "peerDependencies": {
-    "@eslint/markdown": "^7.0.0 || ^8.0.0",
+    "@eslint/markdown": "^7.0.0 || ^8.0.3",
     "@stylistic/eslint-plugin": "^5.10.0",
     "@vitest/eslint-plugin": "*",
     "eslint": ">=9",
@@ -26,7 +26,7 @@
     "typescript-eslint": "^8.58.0"
   },
   "devDependencies": {
-    "@eslint/markdown": "^8.0.0",
+    "@eslint/markdown": "^8.0.3",
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@sourceacademy/modules-lib": "workspace:^",
     "@sourceacademy/modules-repotools": "workspace:^",

--- a/lib/markdown-tree/package.json
+++ b/lib/markdown-tree/package.json
@@ -9,7 +9,7 @@
     "@sourceacademy/modules-repotools": "workspace:^",
     "@types/markdown-it": "^14.1.2",
     "shiki": "^2.1.0",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "exports": {
     ".": {

--- a/lib/modules-lib/package.json
+++ b/lib/modules-lib/package.json
@@ -15,7 +15,7 @@
     "typedoc-plugin-frontmatter": "^1.3.0",
     "typedoc-plugin-markdown": "^4.7.0",
     "typedoc-plugin-rename-defaults": "^0.7.3",
-    "typescript": "^6.0.2",
+    "typescript": "catalog:",
     "vitest": "catalog:",
     "vitest-browser-react": "^2.1.0"
   },

--- a/lib/repotools/package.json
+++ b/lib/repotools/package.json
@@ -9,7 +9,7 @@
     "@types/node": "^24.0.0",
     "@vitejs/plugin-react": "^6.0.3",
     "@vitest/coverage-v8": "catalog:",
-    "typescript": "^6.0.2",
+    "typescript": "catalog:",
     "vitest": "catalog:",
     "vitest-browser-react": "^2.1.0"
   },

--- a/lib/typedoc-plugin/package.json
+++ b/lib/typedoc-plugin/package.json
@@ -13,7 +13,7 @@
     "@types/node": "^24.0.0",
     "js-slang": "catalog:",
     "typedoc": "^0.28.18",
-    "typescript": "^6.0.2",
+    "typescript": "catalog:",
     "vitest": "catalog:"
   },
   "peerDependencies": {

--- a/lib/vitest-reporter/package.json
+++ b/lib/vitest-reporter/package.json
@@ -12,7 +12,7 @@
     "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "catalog:",
     "esbuild": "^0.28.1",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "exports": {
     "./coverage-reporter": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "jsonc-eslint-parser": "^3.1.0",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "typescript": "^6.0.2",
+    "typescript": "catalog:",
     "typescript-eslint": "^8.58.2",
     "vitest": "catalog:",
     "vitest-browser-react": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",
-    "@eslint/markdown": "^8.0.0",
+    "@eslint/markdown": "^8.0.3",
     "@sourceacademy/lint-plugin": "workspace:^",
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@sourceacademy/modules-lib": "workspace:^",

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":label(dependencies)"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,20 @@
   "extends": [
     "config:recommended",
     ":label(dependencies)"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "*"
+      ],
+      // Match the release gate in `.yarnrc.yml`
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "matchPackageNames": [
+        "/^@blueprintjs.*/"
+      ],
+      "groupName": "blueprintjs"
+    }
   ]
 }

--- a/src/archive/bundles/ar/package.json
+++ b/src/archive/bundles/ar/package.json
@@ -18,7 +18,7 @@
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "typescript": "^6.0.0"
+    "typescript": "catalog:"
   },
   "scripts": {
     "build": "buildtools build bundle .",

--- a/src/bundles/arcade_2d/package.json
+++ b/src/bundles/arcade_2d/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@sourceacademy/modules-lib": "workspace:^",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/binary_tree/package.json
+++ b/src/bundles/binary_tree/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/communication/package.json
+++ b/src/bundles/communication/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/uniqid": "^5.3.4",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/copy_gc/package.json
+++ b/src/bundles/copy_gc/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@sourceacademy/modules-lib": "workspace:^",

--- a/src/bundles/csg/package.json
+++ b/src/bundles/csg/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "scripts": {

--- a/src/bundles/curve/package.json
+++ b/src/bundles/curve/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/game/package.json
+++ b/src/bundles/game/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/mark_sweep/package.json
+++ b/src/bundles/mark_sweep/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/midi/package.json
+++ b/src/bundles/midi/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@sourceacademy/modules-lib": "workspace:^",

--- a/src/bundles/nbody/package.json
+++ b/src/bundles/nbody/package.json
@@ -12,7 +12,7 @@
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/plotly.js": "^2.35.4",
     "@types/three": "^0.185.0",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/painter/package.json
+++ b/src/bundles/painter/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/plotly.js": "^3.0.0",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/physics_2d/package.json
+++ b/src/bundles/physics_2d/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/pix_n_flix/package.json
+++ b/src/bundles/pix_n_flix/package.json
@@ -9,7 +9,7 @@
     "playwright": "^1.55.1",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "typescript": "^6.0.2",
+    "typescript": "catalog:",
     "vitest": "catalog:",
     "vitest-browser-react": "^2.1.0"
   },

--- a/src/bundles/plotly/package.json
+++ b/src/bundles/plotly/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/plotly.js": "^3.0.0",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/repeat/package.json
+++ b/src/bundles/repeat/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
     "js-slang": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/repl/package.json
+++ b/src/bundles/repl/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/robot_simulation/package.json
+++ b/src/bundles/robot_simulation/package.json
@@ -12,7 +12,7 @@
     "@dimforge/rapier3d-compat": "^0.11.2",
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/three": "^0.185.0",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/rune/package.json
+++ b/src/bundles/rune/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
     "js-slang": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/rune_in_words/package.json
+++ b/src/bundles/rune_in_words/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@sourceacademy/modules-lib": "workspace:^"

--- a/src/bundles/scrabble/package.json
+++ b/src/bundles/scrabble/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/sound/package.json
+++ b/src/bundles/sound/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@sourceacademy/modules-lib": "workspace:^",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/sound_matrix/package.json
+++ b/src/bundles/sound_matrix/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/stereo_sound/package.json
+++ b/src/bundles/stereo_sound/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@sourceacademy/bundle-midi": "workspace:^",

--- a/src/bundles/unittest/package.json
+++ b/src/bundles/unittest/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/unity_academy/package.json
+++ b/src/bundles/unity_academy/package.json
@@ -13,7 +13,7 @@
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "exports": {

--- a/src/bundles/wasm/package.json
+++ b/src/bundles/wasm/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "source-academy-utils": "^1.0.0",

--- a/src/tabs/ArcadeTwod/package.json
+++ b/src/tabs/ArcadeTwod/package.json
@@ -13,7 +13,7 @@
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "scripts": {
     "build": "buildtools build tab .",

--- a/src/tabs/CopyGc/package.json
+++ b/src/tabs/CopyGc/package.json
@@ -13,7 +13,7 @@
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "scripts": {
     "build": "buildtools build tab .",

--- a/src/tabs/Csg/package.json
+++ b/src/tabs/Csg/package.json
@@ -13,7 +13,7 @@
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "scripts": {
     "build": "buildtools build tab .",

--- a/src/tabs/Curve/package.json
+++ b/src/tabs/Curve/package.json
@@ -16,7 +16,7 @@
     "@vitest/browser-playwright": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "playwright": "^1.55.1",
-    "typescript": "^6.0.2",
+    "typescript": "catalog:",
     "vitest": "catalog:",
     "vitest-browser-react": "^2.1.0"
   },

--- a/src/tabs/Game/package.json
+++ b/src/tabs/Game/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "scripts": {
     "build": "buildtools build tab .",

--- a/src/tabs/MarkSweep/package.json
+++ b/src/tabs/MarkSweep/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "scripts": {
     "build": "buildtools build tab .",

--- a/src/tabs/Nbody/package.json
+++ b/src/tabs/Nbody/package.json
@@ -17,7 +17,7 @@
     "@types/plotly.js": "^2.35.4",
     "@types/react": "catalog:",
     "@types/three": "^0.185.0",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "scripts": {
     "build": "buildtools build tab .",

--- a/src/tabs/Painter/package.json
+++ b/src/tabs/Painter/package.json
@@ -12,7 +12,7 @@
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "scripts": {
     "build": "buildtools build tab .",

--- a/src/tabs/Physics2D/package.json
+++ b/src/tabs/Physics2D/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "scripts": {
     "build": "buildtools build tab .",

--- a/src/tabs/Pixnflix/package.json
+++ b/src/tabs/Pixnflix/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "scripts": {
     "build": "buildtools build tab .",

--- a/src/tabs/Plotly/package.json
+++ b/src/tabs/Plotly/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "scripts": {
     "build": "buildtools build tab .",

--- a/src/tabs/Repeat/package.json
+++ b/src/tabs/Repeat/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "scripts": {
     "build": "buildtools build tab .",

--- a/src/tabs/Repl/package.json
+++ b/src/tabs/Repl/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "scripts": {
     "build": "buildtools build tab .",

--- a/src/tabs/RobotSimulation/package.json
+++ b/src/tabs/RobotSimulation/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "scripts": {
     "build": "buildtools build tab .",

--- a/src/tabs/Rune/package.json
+++ b/src/tabs/Rune/package.json
@@ -14,7 +14,7 @@
     "@types/react": "catalog:",
     "@vitest/browser-playwright": "catalog:",
     "playwright": "^1.55.1",
-    "typescript": "^6.0.2",
+    "typescript": "catalog:",
     "vitest": "catalog:",
     "vitest-browser-react": "^2.1.0"
   },

--- a/src/tabs/Sound/package.json
+++ b/src/tabs/Sound/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "scripts": {
     "build": "buildtools build tab .",

--- a/src/tabs/SoundMatrix/package.json
+++ b/src/tabs/SoundMatrix/package.json
@@ -13,7 +13,7 @@
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "scripts": {
     "build": "buildtools build tab .",

--- a/src/tabs/StereoSound/package.json
+++ b/src/tabs/StereoSound/package.json
@@ -12,7 +12,7 @@
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "scripts": {
     "build": "buildtools build tab .",

--- a/src/tabs/Unittest/package.json
+++ b/src/tabs/Unittest/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "scripts": {
     "build": "buildtools build tab .",

--- a/src/tabs/UnityAcademy/package.json
+++ b/src/tabs/UnityAcademy/package.json
@@ -13,7 +13,7 @@
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "typescript": "^6.0.2"
+    "typescript": "catalog:"
   },
   "type": "module",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3907,7 +3907,7 @@ __metadata:
     "@sourceacademy/modules-buildtools": "workspace:^"
     "@sourceacademy/modules-lib": "workspace:^"
     phaser: "npm:^3.54.0"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -3918,7 +3918,7 @@ __metadata:
     "@sourceacademy/modules-buildtools": "workspace:^"
     "@sourceacademy/modules-lib": "workspace:^"
     js-slang: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -3931,7 +3931,7 @@ __metadata:
     "@types/uniqid": "npm:^5.3.4"
     mqtt: "npm:^4.3.7"
     os: "npm:^0.1.2"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
     uniqid: "npm:^5.4.0"
   languageName: unknown
   linkType: soft
@@ -3943,7 +3943,7 @@ __metadata:
     "@sourceacademy/modules-buildtools": "workspace:^"
     "@sourceacademy/modules-lib": "workspace:^"
     es-toolkit: "npm:^1.44.0"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -3958,7 +3958,7 @@ __metadata:
     "@sourceacademy/modules-lib": "workspace:^"
     js-slang: "catalog:"
     save-file: "npm:^2.3.1"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -3971,7 +3971,7 @@ __metadata:
     es-toolkit: "npm:^1.44.0"
     gl-matrix: "npm:^3.3.0"
     js-slang: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -3982,7 +3982,7 @@ __metadata:
     "@sourceacademy/modules-buildtools": "workspace:^"
     js-slang: "catalog:"
     phaser: "npm:^3.54.0"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -3992,7 +3992,7 @@ __metadata:
   dependencies:
     "@sourceacademy/modules-buildtools": "workspace:^"
     es-toolkit: "npm:^1.44.0"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4003,7 +4003,7 @@ __metadata:
     "@sourceacademy/modules-buildtools": "workspace:^"
     "@sourceacademy/modules-lib": "workspace:^"
     js-slang: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4018,7 +4018,7 @@ __metadata:
     nbody: "npm:^0.2.0"
     plotly.js-dist: "npm:^2.17.1"
     three: "npm:^0.185.0"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4030,7 +4030,7 @@ __metadata:
     "@sourceacademy/modules-lib": "workspace:^"
     "@types/plotly.js": "npm:^3.0.0"
     plotly.js-dist: "npm:^3.0.0"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4041,7 +4041,7 @@ __metadata:
     "@box2d/core": "npm:^0.10.0"
     "@sourceacademy/modules-buildtools": "workspace:^"
     "@sourceacademy/modules-lib": "workspace:^"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4056,7 +4056,7 @@ __metadata:
     playwright: "npm:^1.55.1"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
     vitest: "catalog:"
     vitest-browser-react: "npm:^2.1.0"
   languageName: unknown
@@ -4073,7 +4073,7 @@ __metadata:
     "@types/plotly.js": "npm:^3.0.0"
     js-slang: "catalog:"
     plotly.js-dist: "npm:^3.0.0"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4084,7 +4084,7 @@ __metadata:
     "@sourceacademy/modules-buildtools": "workspace:^"
     "@sourceacademy/modules-lib": "workspace:^"
     js-slang: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4095,7 +4095,7 @@ __metadata:
     "@sourceacademy/modules-buildtools": "workspace:^"
     "@sourceacademy/modules-lib": "workspace:^"
     js-slang: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4110,7 +4110,7 @@ __metadata:
     es-toolkit: "npm:^1.44.0"
     js-slang: "catalog:"
     three: "npm:^0.185.0"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4124,7 +4124,7 @@ __metadata:
     es-toolkit: "npm:^1.44.0"
     gl-matrix: "npm:^3.3.0"
     js-slang: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4134,7 +4134,7 @@ __metadata:
   dependencies:
     "@sourceacademy/modules-buildtools": "workspace:^"
     "@sourceacademy/modules-lib": "workspace:^"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4143,7 +4143,7 @@ __metadata:
   resolution: "@sourceacademy/bundle-scrabble@workspace:src/bundles/scrabble"
   dependencies:
     "@sourceacademy/modules-buildtools": "workspace:^"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4155,7 +4155,7 @@ __metadata:
     "@sourceacademy/modules-buildtools": "workspace:^"
     "@sourceacademy/modules-lib": "workspace:^"
     js-slang: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4165,7 +4165,7 @@ __metadata:
   dependencies:
     "@sourceacademy/modules-buildtools": "workspace:^"
     js-slang: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4177,7 +4177,7 @@ __metadata:
     "@sourceacademy/modules-buildtools": "workspace:^"
     "@sourceacademy/modules-lib": "workspace:^"
     js-slang: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4189,7 +4189,7 @@ __metadata:
     "@sourceacademy/modules-lib": "workspace:^"
     es-toolkit: "npm:^1.44.0"
     js-slang: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4205,7 +4205,7 @@ __metadata:
     "@types/react-dom": "catalog:"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4216,7 +4216,7 @@ __metadata:
     "@sourceacademy/modules-buildtools": "workspace:^"
     source-academy-utils: "npm:^1.0.0"
     source-academy-wabt: "npm:^1.0.4"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4239,7 +4239,7 @@ __metadata:
     eslint-plugin-react-hooks: "npm:^7.0.1"
     globals: "npm:^17.0.0"
     js-slang: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
     typescript-eslint: "npm:^8.58.2"
   peerDependencies:
     "@eslint/markdown": ^7.0.0 || ^8.0.0
@@ -4265,7 +4265,7 @@ __metadata:
     "@types/markdown-it": "npm:^14.1.2"
     es-toolkit: "npm:^1.44.0"
     shiki: "npm:^2.1.0"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
     yaml: "npm:^2.8.0"
   peerDependencies:
     markdown-it: "*"
@@ -4295,7 +4295,7 @@ __metadata:
     http-server: "npm:^14.1.1"
     jsdom: "npm:^29.0.0"
     typedoc: "npm:^0.28.18"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
     vite: "npm:^8.1.0"
     vitest: "catalog:"
   bin:
@@ -4327,7 +4327,7 @@ __metadata:
     react-ace: "npm:^14.0.0"
     react-dom: "catalog:"
     sass: "npm:^1.85.0"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
     vite: "npm:^8.1.0"
     vite-plugin-node-polyfills: "npm:^0.28.0"
     vitest: "catalog:"
@@ -4352,7 +4352,7 @@ __metadata:
     cspell: "npm:^10.0.0"
     js-slang: "catalog:"
     mermaid: "npm:^11.10.0"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
     vitepress: "npm:^1.6.4"
     vitepress-plugin-group-icons: "npm:^1.7.5"
     vitepress-plugin-mermaid: "npm:^2.0.17"
@@ -4371,7 +4371,7 @@ __metadata:
     "@types/node": "npm:^24.0.0"
     es-toolkit: "npm:^1.44.0"
     snyk-nodejs-lockfile-parser: "npm:^2.4.2"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
     vitest: "catalog:"
   languageName: unknown
   linkType: soft
@@ -4396,7 +4396,7 @@ __metadata:
     typedoc-plugin-frontmatter: "npm:^1.3.0"
     typedoc-plugin-markdown: "npm:^4.7.0"
     typedoc-plugin-rename-defaults: "npm:^0.7.3"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
     vitest: "catalog:"
     vitest-browser-react: "npm:^2.1.0"
   languageName: unknown
@@ -4416,7 +4416,7 @@ __metadata:
     es-toolkit: "npm:^1.44.0"
     esbuild: "npm:^0.28.1"
     jsonschema: "npm:^1.5.0"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
     vitest: "catalog:"
     vitest-browser-react: "npm:^2.1.0"
   peerDependencies:
@@ -4435,7 +4435,7 @@ __metadata:
     acorn-typescript: "npm:^1.4.13"
     js-slang: "catalog:"
     typedoc: "npm:^0.28.18"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
     vitest: "catalog:"
   peerDependencies:
     js-slang: "*"
@@ -4476,7 +4476,7 @@ __metadata:
     jsonc-eslint-parser: "npm:^3.1.0"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
     typescript-eslint: "npm:^8.58.2"
     vitest: "catalog:"
     vitest-browser-react: "npm:^2.1.0"
@@ -4502,7 +4502,7 @@ __metadata:
     phaser: "npm:^3.54.0"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4518,7 +4518,7 @@ __metadata:
     "@types/react-dom": "catalog:"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4534,7 +4534,7 @@ __metadata:
     "@types/react-dom": "catalog:"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4553,7 +4553,7 @@ __metadata:
     playwright: "npm:^1.55.1"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
     vitest: "catalog:"
     vitest-browser-react: "npm:^2.1.0"
   languageName: unknown
@@ -4568,7 +4568,7 @@ __metadata:
     "@types/react": "catalog:"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4583,7 +4583,7 @@ __metadata:
     "@types/react": "catalog:"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4603,7 +4603,7 @@ __metadata:
     react: "catalog:"
     react-dom: "catalog:"
     three: "npm:^0.185.0"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4618,7 +4618,7 @@ __metadata:
     "@types/react-dom": "catalog:"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4634,7 +4634,7 @@ __metadata:
     "@types/react": "catalog:"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4649,7 +4649,7 @@ __metadata:
     "@types/react": "catalog:"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4663,7 +4663,7 @@ __metadata:
     "@types/react": "catalog:"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4676,7 +4676,7 @@ __metadata:
     "@types/react": "catalog:"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4694,7 +4694,7 @@ __metadata:
     react: "catalog:"
     react-ace: "npm:^14.0.0"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4710,7 +4710,7 @@ __metadata:
     "@types/react": "catalog:"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4727,7 +4727,7 @@ __metadata:
     playwright: "npm:^1.55.1"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
     vitest: "catalog:"
     vitest-browser-react: "npm:^2.1.0"
   languageName: unknown
@@ -4743,7 +4743,7 @@ __metadata:
     "@types/react": "catalog:"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4759,7 +4759,7 @@ __metadata:
     classnames: "npm:^2.3.1"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4774,7 +4774,7 @@ __metadata:
     "@types/react-dom": "catalog:"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4789,7 +4789,7 @@ __metadata:
     es-toolkit: "npm:^1.44.0"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4805,7 +4805,7 @@ __metadata:
     "@types/react-dom": "catalog:"
     react: "catalog:"
     react-dom: "catalog:"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -4818,7 +4818,7 @@ __metadata:
     "@vitest/coverage-v8": "catalog:"
     esbuild: "npm:^0.28.1"
     istanbul-lib-report: "npm:^3.0.1"
-    typescript: "npm:^6.0.2"
+    typescript: "catalog:"
     vitest: "catalog:"
   languageName: unknown
   linkType: soft
@@ -17417,7 +17417,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^6.0.2":
+"typescript@npm:^6.0.3":
   version: 6.0.3
   resolution: "typescript@npm:6.0.3"
   bin:
@@ -17457,7 +17457,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^6.0.2#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
   version: 6.0.3
   resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2371,12 +2371,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/markdown@npm:^8.0.0":
-  version: 8.0.2
-  resolution: "@eslint/markdown@npm:8.0.2"
+"@eslint/markdown@npm:^8.0.3":
+  version: 8.0.3
+  resolution: "@eslint/markdown@npm:8.0.3"
   dependencies:
     "@eslint/core": "npm:^1.2.1"
-    "@eslint/plugin-kit": "npm:^0.7.1"
+    "@eslint/plugin-kit": "npm:^0.7.2"
     github-slugger: "npm:^2.0.0"
     mdast-util-from-markdown: "npm:^2.0.2"
     mdast-util-frontmatter: "npm:^2.0.1"
@@ -2386,7 +2386,7 @@ __metadata:
     micromark-extension-gfm: "npm:^3.0.0"
     micromark-extension-math: "npm:^3.1.0"
     micromark-util-normalize-identifier: "npm:^2.0.1"
-  checksum: 10c0/3893ede905f6bcd954173b4c432c402c94a9eacbe539e99e4b365d3fa9275e7c175531781cbd637654acdf6f1f84faf74894674fee51d8354af7a0cf353e3fa4
+  checksum: 10c0/00f65a81786c5d286bf029a5eeb69a04bdd4993e363cd1a77b86100532440e47d46ae7757995515862513af3368a263f739fe5af170a5092af6bd8ef25cc980d
   languageName: node
   linkType: hard
 
@@ -2407,7 +2407,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/plugin-kit@npm:^0.7.0, @eslint/plugin-kit@npm:^0.7.1":
+"@eslint/plugin-kit@npm:^0.7.0, @eslint/plugin-kit@npm:^0.7.2":
   version: 0.7.2
   resolution: "@eslint/plugin-kit@npm:0.7.2"
   dependencies:
@@ -4224,7 +4224,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sourceacademy/lint-plugin@workspace:lib/lintplugin"
   dependencies:
-    "@eslint/markdown": "npm:^8.0.0"
+    "@eslint/markdown": "npm:^8.0.3"
     "@sourceacademy/modules-buildtools": "workspace:^"
     "@sourceacademy/modules-lib": "workspace:^"
     "@sourceacademy/modules-repotools": "workspace:^"
@@ -4242,7 +4242,7 @@ __metadata:
     typescript: "catalog:"
     typescript-eslint: "npm:^8.58.2"
   peerDependencies:
-    "@eslint/markdown": ^7.0.0 || ^8.0.0
+    "@eslint/markdown": ^7.0.0 || ^8.0.3
     "@stylistic/eslint-plugin": ^5.10.0
     "@vitest/eslint-plugin": "*"
     eslint: ">=9"
@@ -4448,7 +4448,7 @@ __metadata:
   resolution: "@sourceacademy/modules@workspace:."
   dependencies:
     "@eslint/js": "npm:^9.35.0"
-    "@eslint/markdown": "npm:^8.0.0"
+    "@eslint/markdown": "npm:^8.0.3"
     "@sourceacademy/lint-plugin": "workspace:^"
     "@sourceacademy/modules-buildtools": "workspace:^"
     "@sourceacademy/modules-lib": "workspace:^"


### PR DESCRIPTION
# Description

Due to a bug with `@eslint/markdown` v8 type definitions (fixed in 8.0.3 as per their changelog). Also moved `typescript` to Yarn catalog to standardize version, and updates Renovate config to match supply chain policies.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)