### PR TITLE
Migrate binary_tree module to Conductor

### DIFF
--- a/src/bundles/binary_tree/package.json
+++ b/src/bundles/binary_tree/package.json
@@ -2,11 +2,10 @@
   "name": "@sourceacademy/bundle-binary_tree",
   "version": "1.0.0",
   "private": true,
-  "dependencies": {
-    "js-slang": "^1.0.85"
-  },
   "devDependencies": {
+    "@sourceacademy/conductor": "https://github.com/source-academy/conductor",
     "@sourceacademy/modules-buildtools": "workspace:^",
+    "@sourceacademy/modules-testplugin": "workspace:^",
     "typescript": "^6.0.2"
   },
   "type": "module",

--- a/src/bundles/binary_tree/src/__tests__/index.test.ts
+++ b/src/bundles/binary_tree/src/__tests__/index.test.ts
@@ -64,6 +64,22 @@ describe(funcs.is_tree, () => {
   });
 });
 
+describe(funcs.make_tree, () => {
+  it('throws when left is not a tree', async () => {
+    const handler = new TestDataHandler();
+    await expect(
+      funcs.make_tree(handler, await opaqueNumber(handler, 0), numberValue(0) as unknown as TypedValue<DataType.LIST>, funcs.make_empty_tree())
+    ).rejects.toThrowError('make_tree expects binary tree for left');
+  });
+
+  it('throws when right is not a tree', async () => {
+    const handler = new TestDataHandler();
+    await expect(
+      funcs.make_tree(handler, await opaqueNumber(handler, 0), funcs.make_empty_tree(), numberValue(0) as unknown as TypedValue<DataType.LIST>)
+    ).rejects.toThrowError('make_tree expects binary tree for right');
+  });
+});
+
 describe(funcs.entry, () => {
   it('throws when argument is not a tree', async () => {
     const handler = new TestDataHandler();

--- a/src/bundles/binary_tree/src/__tests__/index.test.ts
+++ b/src/bundles/binary_tree/src/__tests__/index.test.ts
@@ -1,109 +1,188 @@
-import { list } from 'js-slang/dist/stdlib/list';
+import { DataType, type TypedValue } from '@sourceacademy/conductor/types';
+import { TestDataHandler, emptyListValue, numberValue } from '@sourceacademy/modules-testplugin';
 import { describe, expect, it } from 'vitest';
 import * as funcs from '../functions';
 
+async function opaqueNumber(handler: TestDataHandler, value: number) {
+  return handler.opaque_make(value) as Promise<TypedValue<DataType.OPAQUE>>;
+}
+
+async function rawTree(
+  handler: TestDataHandler,
+  value: number,
+  left: TypedValue<DataType>,
+  right: TypedValue<DataType>
+) {
+  return handler.pair_make(
+    await opaqueNumber(handler, value),
+    await handler.pair_make(left, await handler.pair_make(right, emptyListValue()))
+  );
+}
+
 describe(funcs.is_tree, () => {
-  it('returns false when argument is not a tree', () => {
-    const arg = [0, [0, null]];
-    expect(funcs.is_tree(arg)).toEqual(false);
+  it('returns false when argument is not a list', async () => {
+    const handler = new TestDataHandler();
+    await expect(funcs.is_tree(handler, numberValue(0))).resolves.toEqual(false);
   });
 
-  it('returns false when argument is a list of 4 elements', () => {
-    const arg = list(0, funcs.make_empty_tree(), funcs.make_empty_tree(), funcs.make_empty_tree());
-    expect(funcs.is_tree(arg)).toEqual(false);
+  it('returns false when argument is a list of 4 elements', async () => {
+    const handler = new TestDataHandler();
+    const arg = await handler.list(
+      numberValue(0),
+      funcs.make_empty_tree(),
+      funcs.make_empty_tree(),
+      funcs.make_empty_tree()
+    );
+    await expect(funcs.is_tree(handler, arg)).resolves.toEqual(false);
   });
 
-  it('returns false when the branches are not trees', () => {
-    const not_tree = list(0, 1, 2);
-    expect(funcs.is_tree(not_tree)).toEqual(false);
+  it('returns false when the branches are not trees', async () => {
+    const handler = new TestDataHandler();
+    const notTree = await handler.list(numberValue(0), numberValue(1), numberValue(2));
+    await expect(funcs.is_tree(handler, notTree)).resolves.toEqual(false);
 
-    const also_not_tree = list(1, not_tree, null);
-    expect(funcs.is_tree(also_not_tree)).toEqual(false);
+    const alsoNotTree = await handler.list(numberValue(1), notTree, emptyListValue());
+    await expect(funcs.is_tree(handler, alsoNotTree)).resolves.toEqual(false);
   });
 
-  it('returns true when argument is a tree (simple)', () => {
-    const arg = [0, [null, [null, null]]];
-    expect(funcs.is_tree(arg)).toEqual(true);
+  it('returns true when argument is a tree (simple)', async () => {
+    const handler = new TestDataHandler();
+    const tree = await rawTree(handler, 0, emptyListValue(), emptyListValue());
+    await expect(funcs.is_tree(handler, tree)).resolves.toEqual(true);
   });
 
-  it('returns true when argument is a tree (complex)', () => {
-    const arg = [
-      0,
-      [
-        [0, [null, [null, null]]],
-        [
-          [
-            1,
-            [
-              null,
-              [null, null]
-            ]
-          ],
-          null
-        ]
-      ]
-    ];
-    expect(funcs.is_tree(arg)).toEqual(true);
+  it('returns true when argument is a tree (complex)', async () => {
+    const handler = new TestDataHandler();
+    const leftLeaf = await rawTree(handler, 0, emptyListValue(), emptyListValue());
+    const rightLeaf = await rawTree(handler, 1, emptyListValue(), emptyListValue());
+    const rightSubtree = await handler.pair_make(rightLeaf, emptyListValue());
+    const tree = await handler.pair_make(
+      await opaqueNumber(handler, 0),
+      await handler.pair_make(leftLeaf, rightSubtree)
+    );
+    await expect(funcs.is_tree(handler, tree)).resolves.toEqual(true);
   });
 });
 
 describe(funcs.entry, () => {
-  it('throws when argument is not a tree', () => {
-    expect(() => funcs.entry(0 as any)).toThrowError('entry expects binary tree, received: 0');
+  it('throws when argument is not a tree', async () => {
+    const handler = new TestDataHandler();
+    await expect(funcs.entry(handler, numberValue(0))).rejects.toThrowError('entry expects binary tree');
   });
 
-  it('throws when argument is an empty tree', () => {
-    expect(() => funcs.entry(null)).toThrowError('entry received an empty binary tree!');
+  it('throws when argument is an empty tree', async () => {
+    const handler = new TestDataHandler();
+    await expect(funcs.entry(handler, emptyListValue())).rejects.toThrowError(
+      'entry received an empty binary tree!'
+    );
   });
 
-  it('works', () => {
-    const tree = funcs.make_tree(0, null, null);
-    expect(funcs.entry(tree)).toEqual(0);
+  it('works', async () => {
+    const handler = new TestDataHandler();
+    const tree = await funcs.make_tree(
+      handler,
+      await opaqueNumber(handler, 0),
+      funcs.make_empty_tree(),
+      funcs.make_empty_tree()
+    );
+    const result = await funcs.entry(handler, tree);
+    await expect(handler.opaque_get(result)).resolves.toEqual(0);
   });
 });
 
 describe(funcs.left_branch, () => {
-  it('throws when argument is not a tree', () => {
-    expect(() => funcs.left_branch(0 as any)).toThrowError('left_branch expects binary tree, received: 0');
+  it('throws when argument is not a tree', async () => {
+    const handler = new TestDataHandler();
+    await expect(funcs.left_branch(handler, numberValue(0))).rejects.toThrowError('left_branch expects binary tree');
   });
 
-  it('throws when argument is an empty tree', () => {
-    expect(() => funcs.left_branch(null)).toThrowError('left_branch received an empty binary tree!');
+  it('throws when argument is an empty tree', async () => {
+    const handler = new TestDataHandler();
+    await expect(funcs.left_branch(handler, emptyListValue())).rejects.toThrowError(
+      'left_branch received an empty binary tree!'
+    );
   });
 
-  it('works (simple)', () => {
-    const tree = funcs.make_tree(0, null, null);
-    expect(funcs.left_branch(tree)).toEqual(null);
+  it('works (simple)', async () => {
+    const handler = new TestDataHandler();
+    const tree = await funcs.make_tree(
+      handler,
+      await opaqueNumber(handler, 0),
+      funcs.make_empty_tree(),
+      funcs.make_empty_tree()
+    );
+    const left = await funcs.left_branch(handler, tree);
+    expect(left.type).toEqual(DataType.EMPTY_LIST);
   });
 
-  it('works (complex)', () => {
-    const tree = funcs.make_tree(0, funcs.make_tree(1, null, null), null);
-    expect(funcs.entry(tree)).toEqual(0);
+  it('works (complex)', async () => {
+    const handler = new TestDataHandler();
+    const innerTree = await funcs.make_tree(
+      handler,
+      await opaqueNumber(handler, 1),
+      funcs.make_empty_tree(),
+      funcs.make_empty_tree()
+    );
+    const tree = await funcs.make_tree(
+      handler,
+      await opaqueNumber(handler, 0),
+      innerTree,
+      funcs.make_empty_tree()
+    );
 
-    const leftTree = funcs.left_branch(tree);
-    expect(funcs.entry(leftTree)).toEqual(1);
+    await expect(handler.opaque_get(await funcs.entry(handler, tree))).resolves.toEqual(0);
+
+    const leftTree = await funcs.left_branch(handler, tree);
+    await expect(handler.opaque_get(await funcs.entry(handler, leftTree))).resolves.toEqual(1);
   });
 });
 
 describe(funcs.right_branch, () => {
-  it('throws when argument is not a tree', () => {
-    expect(() => funcs.right_branch(0 as any)).toThrowError('right_branch expects binary tree, received: 0');
+  it('throws when argument is not a tree', async () => {
+    const handler = new TestDataHandler();
+    await expect(funcs.right_branch(handler, numberValue(0))).rejects.toThrowError(
+      'right_branch expects binary tree'
+    );
   });
 
-  it('throws when argument is an empty tree', () => {
-    expect(() => funcs.right_branch(null)).toThrowError('right_branch received an empty binary tree!');
+  it('throws when argument is an empty tree', async () => {
+    const handler = new TestDataHandler();
+    await expect(funcs.right_branch(handler, emptyListValue())).rejects.toThrowError(
+      'right_branch received an empty binary tree!'
+    );
   });
 
-  it('works (simple)', () => {
-    const tree = funcs.make_tree(0, null, null);
-    expect(funcs.right_branch(tree)).toEqual(null);
+  it('works (simple)', async () => {
+    const handler = new TestDataHandler();
+    const tree = await funcs.make_tree(
+      handler,
+      await opaqueNumber(handler, 0),
+      funcs.make_empty_tree(),
+      funcs.make_empty_tree()
+    );
+    const right = await funcs.right_branch(handler, tree);
+    expect(right.type).toEqual(DataType.EMPTY_LIST);
   });
 
-  it('works (complex)', () => {
-    const tree = funcs.make_tree(0, funcs.make_tree(1, null, null), funcs.make_tree(2, null, null));
-    expect(funcs.entry(tree)).toEqual(0);
+  it('works (complex)', async () => {
+    const handler = new TestDataHandler();
+    const leftTree = await funcs.make_tree(
+      handler,
+      await opaqueNumber(handler, 1),
+      funcs.make_empty_tree(),
+      funcs.make_empty_tree()
+    );
+    const rightTree = await funcs.make_tree(
+      handler,
+      await opaqueNumber(handler, 2),
+      funcs.make_empty_tree(),
+      funcs.make_empty_tree()
+    );
+    const tree = await funcs.make_tree(handler, await opaqueNumber(handler, 0), leftTree, rightTree);
 
-    const rightTree = funcs.right_branch(tree);
-    expect(funcs.entry(rightTree)).toEqual(2);
+    await expect(handler.opaque_get(await funcs.entry(handler, tree))).resolves.toEqual(0);
+
+    const right = await funcs.right_branch(handler, tree);
+    await expect(handler.opaque_get(await funcs.entry(handler, right))).resolves.toEqual(2);
   });
 });

--- a/src/bundles/binary_tree/src/functions.ts
+++ b/src/bundles/binary_tree/src/functions.ts
@@ -34,6 +34,14 @@ export async function make_tree(
   left: BinaryTree,
   right: BinaryTree
 ): Promise<NonEmptyBinaryTree> {
+  if (!await is_tree(evaluator, left)) {
+    throw new EvaluatorTypeError(`${make_tree.name} expects binary tree for left`, 'binary tree', DataType[left.type]);
+  }
+
+  if (!await is_tree(evaluator, right)) {
+    throw new EvaluatorTypeError(`${make_tree.name} expects binary tree for right`, 'binary tree', DataType[right.type]);
+  }
+
   const rightPair = await evaluator.pair_make(right, mEmptyList());
   const leftPair = await evaluator.pair_make(left, rightPair);
   return evaluator.pair_make(value, leftPair);

--- a/src/bundles/binary_tree/src/functions.ts
+++ b/src/bundles/binary_tree/src/functions.ts
@@ -51,6 +51,7 @@ export async function make_tree(
  * @param value Value to be tested. May be of any Conductor DataType.
  */
 export async function is_tree(evaluator: IDataHandler, value: TypedValue<DataType>): Promise<boolean> {
+  if (!value) return false;
   if (value.type === DataType.EMPTY_LIST) return true;
   if (value.type !== DataType.PAIR) return false;
 
@@ -82,7 +83,7 @@ export async function is_tree(evaluator: IDataHandler, value: TypedValue<DataTyp
  * @returns bool
  */
 export function is_empty_tree(value: TypedValue<DataType>): value is TypedValue<DataType.EMPTY_LIST> {
-  return value.type === DataType.EMPTY_LIST;
+  return value?.type === DataType.EMPTY_LIST;
 }
 
 async function assertNonEmptyTree(
@@ -90,8 +91,8 @@ async function assertNonEmptyTree(
   value: TypedValue<DataType>,
   funcName: string
 ): Promise<NonEmptyBinaryTree> {
-  if (!await is_tree(evaluator, value)) {
-    throw new EvaluatorTypeError(`${funcName} expects binary tree`, 'binary tree', DataType[value.type]);
+  if (!value || !await is_tree(evaluator, value)) {
+    throw new EvaluatorTypeError(`${funcName} expects binary tree`, 'binary tree', value ? DataType[value.type] : 'undefined');
   }
 
   if (value.type !== DataType.PAIR) {

--- a/src/bundles/binary_tree/src/functions.ts
+++ b/src/bundles/binary_tree/src/functions.ts
@@ -1,4 +1,6 @@
-import { head, is_list, is_pair, list, tail } from 'js-slang/dist/stdlib/list';
+import { EvaluatorRuntimeError, EvaluatorTypeError } from '@sourceacademy/conductor/common';
+import { DataType, type IDataHandler, type TypedValue } from '@sourceacademy/conductor/types';
+import { mEmptyList } from '@sourceacademy/conductor/util';
 import type { BinaryTree, EmptyBinaryTree, NonEmptyBinaryTree } from './types';
 
 /**
@@ -9,8 +11,8 @@ import type { BinaryTree, EmptyBinaryTree, NonEmptyBinaryTree } from './types';
  * ```
  * @returns An empty binary tree
  */
-export function make_empty_tree(): BinaryTree {
-  return null;
+export function make_empty_tree(): EmptyBinaryTree {
+  return mEmptyList();
 }
 
 /**
@@ -20,13 +22,21 @@ export function make_empty_tree(): BinaryTree {
  * const tree = make_tree(1, make_empty_tree(), make_empty_tree());
  * display(tree); // Shows "[1, [null, [null, null]]]" in the REPL
  * ```
+ * @param evaluator The Conductor data handler for the running evaluator
  * @param value Value to be stored in the node
  * @param left Left subtree of the node
  * @param right Right subtree of the node
  * @returns A binary tree
  */
-export function make_tree(value: any, left: BinaryTree, right: BinaryTree): BinaryTree {
-  return list(value, left, right);
+export async function make_tree(
+  evaluator: IDataHandler,
+  value: TypedValue<DataType.OPAQUE>,
+  left: BinaryTree,
+  right: BinaryTree
+): Promise<NonEmptyBinaryTree> {
+  const rightPair = await evaluator.pair_make(right, mEmptyList());
+  const leftPair = await evaluator.pair_make(left, rightPair);
+  return evaluator.pair_make(value, leftPair);
 }
 
 /**
@@ -37,21 +47,27 @@ export function make_tree(value: any, left: BinaryTree, right: BinaryTree): Bina
  * const tree = make_tree(1, make_empty_tree(), make_empty_tree());
  * display(is_tree(tree)); // Shows "true" in the REPL
  * ```
- * @param value Value to be tested
+ * @param evaluator The Conductor data handler for the running evaluator
+ * @param value Value to be tested. May be of any Conductor DataType.
  */
-export function is_tree(value: any): value is BinaryTree {
-  // TODO: value parameter should be of type unknown
-  if (!is_list(value)) return false;
+export async function is_tree(evaluator: IDataHandler, value: TypedValue<DataType>): Promise<boolean> {
+  if (value.type === DataType.EMPTY_LIST) return true;
+  if (value.type !== DataType.PAIR) return false;
 
-  if (is_empty_tree(value)) return true;
+  const rest = await evaluator.pair_tail(value);
+  if (rest.type !== DataType.PAIR) return false;
 
-  const left = tail(value);
-  if (!is_list(left) || !is_tree(head(left))) return false;
+  const left = await evaluator.pair_head(rest);
+  if (!await is_tree(evaluator, left)) return false;
 
-  const right = tail(left);
-  if (!is_pair(right) || !is_tree(head(right))) return false;
+  const rightRest = await evaluator.pair_tail(rest);
+  if (rightRest.type !== DataType.PAIR) return false;
 
-  return tail(right) === null;
+  const right = await evaluator.pair_head(rightRest);
+  if (!await is_tree(evaluator, right)) return false;
+
+  const tail = await evaluator.pair_tail(rightRest);
+  return tail.type === DataType.EMPTY_LIST;
 }
 
 /**
@@ -62,21 +78,27 @@ export function is_tree(value: any): value is BinaryTree {
  * const tree = make_tree(1, make_empty_tree(), make_empty_tree());
  * display(is_empty_tree(tree)); // Shows "false" in the REPL
  * ```
- * @param value Value to be tested
+ * @param value Value to be tested. May be of any Conductor DataType.
  * @returns bool
  */
-export function is_empty_tree(value: BinaryTree): value is EmptyBinaryTree {
-  return value === null;
+export function is_empty_tree(value: TypedValue<DataType>): value is TypedValue<DataType.EMPTY_LIST> {
+  return value.type === DataType.EMPTY_LIST;
 }
 
-function throwIfNotNonEmptyTree(value: unknown, func_name: string): asserts value is NonEmptyBinaryTree {
-  if (!is_tree(value)) {
-    throw new Error(`${func_name} expects binary tree, received: ${value}`);
+async function assertNonEmptyTree(
+  evaluator: IDataHandler,
+  value: TypedValue<DataType>,
+  funcName: string
+): Promise<NonEmptyBinaryTree> {
+  if (!await is_tree(evaluator, value)) {
+    throw new EvaluatorTypeError(`${funcName} expects binary tree`, 'binary tree', DataType[value.type]);
   }
 
-  if (is_empty_tree(value)) {
-    throw new Error(`${func_name} received an empty binary tree!`);
+  if (value.type !== DataType.PAIR) {
+    throw new EvaluatorRuntimeError(`${funcName} received an empty binary tree!`);
   }
+
+  return value;
 }
 
 /**
@@ -86,12 +108,13 @@ function throwIfNotNonEmptyTree(value: unknown, func_name: string): asserts valu
  * const tree = make_tree(1, make_empty_tree(), make_empty_tree());
  * display(entry(tree)); // Shows "1" in the REPL
  * ```
+ * @param evaluator The Conductor data handler for the running evaluator
  * @param t BinaryTree to be accessed
  * @returns Value
  */
-export function entry(t: BinaryTree): any {
-  throwIfNotNonEmptyTree(t, entry.name);
-  return t[0];
+export async function entry(evaluator: IDataHandler, t: TypedValue<DataType>): Promise<TypedValue<DataType.OPAQUE>> {
+  const tree = await assertNonEmptyTree(evaluator, t, entry.name);
+  return (await evaluator.pair_head(tree)) as TypedValue<DataType.OPAQUE>;
 }
 
 /**
@@ -101,12 +124,14 @@ export function entry(t: BinaryTree): any {
  * const tree = make_tree(1, make_tree(2, make_empty_tree(), make_empty_tree()), make_empty_tree());
  * display(entry(left_branch(tree))); // Shows "2" in the REPL
  * ```
+ * @param evaluator The Conductor data handler for the running evaluator
  * @param t BinaryTree to be accessed
  * @returns BinaryTree
  */
-export function left_branch(t: BinaryTree): BinaryTree {
-  throwIfNotNonEmptyTree(t, left_branch.name);
-  return head(tail(t));
+export async function left_branch(evaluator: IDataHandler, t: TypedValue<DataType>): Promise<BinaryTree> {
+  const tree = await assertNonEmptyTree(evaluator, t, left_branch.name);
+  const rest = await evaluator.pair_tail(tree);
+  return (await evaluator.pair_head(rest as TypedValue<DataType.PAIR>)) as BinaryTree;
 }
 
 /**
@@ -116,10 +141,13 @@ export function left_branch(t: BinaryTree): BinaryTree {
  * const tree = make_tree(1, make_empty_tree(), make_tree(2, make_empty_tree(), make_empty_tree()));
  * display(entry(right_branch(tree))); // Shows "2" in the REPL
  * ```
+ * @param evaluator The Conductor data handler for the running evaluator
  * @param t BinaryTree to be accessed
  * @returns BinaryTree
  */
-export function right_branch(t: BinaryTree): BinaryTree {
-  throwIfNotNonEmptyTree(t, right_branch.name);
-  return head(tail(tail(t)));
+export async function right_branch(evaluator: IDataHandler, t: TypedValue<DataType>): Promise<BinaryTree> {
+  const tree = await assertNonEmptyTree(evaluator, t, right_branch.name);
+  const rest = await evaluator.pair_tail(tree);
+  const rightRest = await evaluator.pair_tail(rest as TypedValue<DataType.PAIR>);
+  return (await evaluator.pair_head(rightRest as TypedValue<DataType.PAIR>)) as BinaryTree;
 }

--- a/src/bundles/binary_tree/src/index.ts
+++ b/src/bundles/binary_tree/src/index.ts
@@ -8,10 +8,11 @@
  * @author Joel Lee
  * @author Loh Xian Ze, Bryan
  */
+import { EvaluatorRuntimeError } from '@sourceacademy/conductor/common';
 import type { IChannel, IConduit } from '@sourceacademy/conductor/conduit';
 import { BaseModulePlugin, moduleMethod } from '@sourceacademy/conductor/module';
 import type { IInterfacableEvaluator } from '@sourceacademy/conductor/runner';
-import { DataType, type TypedValue } from '@sourceacademy/conductor/types';
+import { DataType, type IFunctionSignature, type TypedValue } from '@sourceacademy/conductor/types';
 
 import {
   entry as entry_func,
@@ -37,6 +38,27 @@ export default class BinaryTreeModulePlugin extends BaseModulePlugin {
   static channelAttach = [];
   constructor(conduit: IConduit, channels: IChannel<any>[], evaluator: IInterfacableEvaluator) {
     super(conduit, channels, evaluator);
+    this.__bindExportedMethods();
+  }
+
+  // BaseModulePlugin.initialise() registers each exported method as a detached `this[name]`
+  // reference without binding it, so any evaluator that calls the resulting closure as a bare
+  // function (which is how every evaluator calls closures) gets `this === undefined` inside the
+  // method body. Same workaround as repeat/rune until the upstream fix in conductor lands
+  // (source-academy/conductor#41).
+  private __bindExportedMethods() {
+    for (const name of this.exportedNames) {
+      const method = this[name];
+      if (typeof method !== 'function') continue;
+
+      const signature = (method as { signature?: IFunctionSignature<any, any> }).signature;
+      const boundMethod = method.bind(this) as typeof method & { signature?: IFunctionSignature<any, any> };
+      boundMethod.signature = signature;
+      Object.defineProperty(this, name, {
+        configurable: true,
+        value: boundMethod
+      });
+    }
   }
 
   @moduleMethod([], DataType.EMPTY_LIST)
@@ -57,14 +79,14 @@ export default class BinaryTreeModulePlugin extends BaseModulePlugin {
   // Conductor DataType (not just lists/pairs) and answer false rather than throw.
   @moduleMethod([], DataType.BOOLEAN)
   async* is_tree(value?: TypedValue<DataType>): AsyncGenerator<void, TypedValue<DataType.BOOLEAN>, unknown> {
-    if (!value) throw new Error('is_tree expects 1 argument, received 0');
+    if (!value) throw new EvaluatorRuntimeError('is_tree expects 1 argument, received 0');
     return { type: DataType.BOOLEAN, value: await is_tree_func(this.evaluator, value) };
   }
 
   // Same reasoning as is_tree: must accept a value of any Conductor DataType.
   @moduleMethod([], DataType.BOOLEAN)
   async* is_empty_tree(value?: TypedValue<DataType>): AsyncGenerator<void, TypedValue<DataType.BOOLEAN>, unknown> {
-    if (!value) throw new Error('is_empty_tree expects 1 argument, received 0');
+    if (!value) throw new EvaluatorRuntimeError('is_empty_tree expects 1 argument, received 0');
     return { type: DataType.BOOLEAN, value: is_empty_tree_func(value) };
   }
 

--- a/src/bundles/binary_tree/src/index.ts
+++ b/src/bundles/binary_tree/src/index.ts
@@ -8,12 +8,78 @@
  * @author Joel Lee
  * @author Loh Xian Ze, Bryan
  */
-export {
-  entry,
-  is_empty_tree,
-  is_tree,
-  left_branch,
-  make_empty_tree,
-  make_tree,
-  right_branch
+import type { IChannel, IConduit } from '@sourceacademy/conductor/conduit';
+import { BaseModulePlugin, moduleMethod } from '@sourceacademy/conductor/module';
+import type { IInterfacableEvaluator } from '@sourceacademy/conductor/runner';
+import { DataType, type TypedValue } from '@sourceacademy/conductor/types';
+
+import {
+  entry as entry_func,
+  is_empty_tree as is_empty_tree_func,
+  is_tree as is_tree_func,
+  left_branch as left_branch_func,
+  make_empty_tree as make_empty_tree_func,
+  make_tree as make_tree_func,
+  right_branch as right_branch_func
 } from './functions';
+
+export default class BinaryTreeModulePlugin extends BaseModulePlugin {
+  id = 'binary_tree';
+  exportedNames = [
+    'entry',
+    'is_empty_tree',
+    'is_tree',
+    'left_branch',
+    'make_empty_tree',
+    'make_tree',
+    'right_branch'
+  ] as const;
+  static channelAttach = [];
+  constructor(conduit: IConduit, channels: IChannel<any>[], evaluator: IInterfacableEvaluator) {
+    super(conduit, channels, evaluator);
+  }
+
+  @moduleMethod([], DataType.EMPTY_LIST)
+  async* make_empty_tree(): AsyncGenerator<void, TypedValue<DataType.EMPTY_LIST>, unknown> {
+    return make_empty_tree_func();
+  }
+
+  @moduleMethod([DataType.OPAQUE, DataType.LIST, DataType.LIST], DataType.PAIR)
+  async* make_tree(
+    value: TypedValue<DataType.OPAQUE>,
+    left: TypedValue<DataType.LIST>,
+    right: TypedValue<DataType.LIST>
+  ): AsyncGenerator<void, TypedValue<DataType.PAIR>, unknown> {
+    return await make_tree_func(this.evaluator, value, left, right);
+  }
+
+  // No declared arg type: is_tree is a predicate that must accept a value of any
+  // Conductor DataType (not just lists/pairs) and answer false rather than throw.
+  @moduleMethod([], DataType.BOOLEAN)
+  async* is_tree(value?: TypedValue<DataType>): AsyncGenerator<void, TypedValue<DataType.BOOLEAN>, unknown> {
+    if (!value) throw new Error('is_tree expects 1 argument, received 0');
+    return { type: DataType.BOOLEAN, value: await is_tree_func(this.evaluator, value) };
+  }
+
+  // Same reasoning as is_tree: must accept a value of any Conductor DataType.
+  @moduleMethod([], DataType.BOOLEAN)
+  async* is_empty_tree(value?: TypedValue<DataType>): AsyncGenerator<void, TypedValue<DataType.BOOLEAN>, unknown> {
+    if (!value) throw new Error('is_empty_tree expects 1 argument, received 0');
+    return { type: DataType.BOOLEAN, value: is_empty_tree_func(value) };
+  }
+
+  @moduleMethod([DataType.LIST], DataType.OPAQUE)
+  async* entry(t: TypedValue<DataType.LIST>): AsyncGenerator<void, TypedValue<DataType.OPAQUE>, unknown> {
+    return await entry_func(this.evaluator, t);
+  }
+
+  @moduleMethod([DataType.LIST], DataType.LIST)
+  async* left_branch(t: TypedValue<DataType.LIST>): AsyncGenerator<void, TypedValue<DataType.LIST>, unknown> {
+    return await left_branch_func(this.evaluator, t);
+  }
+
+  @moduleMethod([DataType.LIST], DataType.LIST)
+  async* right_branch(t: TypedValue<DataType.LIST>): AsyncGenerator<void, TypedValue<DataType.LIST>, unknown> {
+    return await right_branch_func(this.evaluator, t);
+  }
+}

--- a/src/bundles/binary_tree/src/types.ts
+++ b/src/bundles/binary_tree/src/types.ts
@@ -1,11 +1,17 @@
-/**
- * An empty binary tree, represented by the empty list `null`
- */
-export type EmptyBinaryTree = null;
+import type { DataType, TypedValue } from '@sourceacademy/conductor/types';
 
 /**
- * A binary tree, represented by a list of length 3.
+ * An empty binary tree, represented by the Conductor empty list.
  */
-export type NonEmptyBinaryTree = [any, [BinaryTree, [BinaryTree, null]]];
+export type EmptyBinaryTree = TypedValue<DataType.EMPTY_LIST>;
 
-export type BinaryTree = NonEmptyBinaryTree | EmptyBinaryTree;
+/**
+ * A non-empty binary tree node, represented by a Conductor Pair of length 3:
+ * `(entry . (left . (right . empty-list)))`.
+ */
+export type NonEmptyBinaryTree = TypedValue<DataType.PAIR>;
+
+/**
+ * A binary tree, represented by a Conductor List of length 3, or the empty list.
+ */
+export type BinaryTree = TypedValue<DataType.LIST>;

--- a/src/bundles/binary_tree/tsconfig.json
+++ b/src/bundles/binary_tree/tsconfig.json
@@ -5,7 +5,9 @@
   ],
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "experimentalDecorators": false,
+    "emitDecoratorMetadata": false
   },
   "typedocOptions": {
     "name": "binary_tree"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3835,8 +3835,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sourceacademy/bundle-binary_tree@workspace:src/bundles/binary_tree"
   dependencies:
+    "@sourceacademy/conductor": "https://github.com/source-academy/conductor"
     "@sourceacademy/modules-buildtools": "workspace:^"
-    js-slang: "npm:^1.0.85"
+    "@sourceacademy/modules-testplugin": "workspace:^"
     typescript: "npm:^6.0.2"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description


Fixes #768

Migrates the `binary_tree` module to be Conductor-ready, following the pattern established by the `repeat` module (#698). `binary_tree` has no tab/visualization component, so this is scoped entirely to `src/bundles/binary_tree/`.

- `functions.ts` is rewritten against Conductor's `IDataHandler` (`pair_make`/`pair_head`/`pair_tail`) instead of js-slang's `stdlib/list`, so tree structure is built from real Conductor Pairs rather than native JS arrays.
- `index.ts` is now a `BaseModulePlugin` subclass with each exported function as a `@moduleMethod`-decorated closure, mirroring `repeat`.
- The stored tree entry value is declared `DataType.OPAQUE` at the module boundary (arbitrary Source/Python values aren't representable as a single concrete `DataType`).
- `is_tree`/`is_empty_tree` declare no argument type, since they're predicates that must accept a value of *any* type and answer `false` rather than throw — a declared type would mean the FFI boundary type-asserts and throws before the predicate body ever runs.
- `tsconfig.json` picked up the same `experimentalDecorators`/`emitDecoratorMetadata` overrides `repeat` already has (this bundle was missing them, which breaks the `moduleMethod` decorator under TS's native Stage-3 decorators).

## Testing

- `yarn workspace @sourceacademy/bundle-binary_tree run tsc` — passes
- `yarn workspace @sourceacademy/bundle-binary_tree run lint` — passes
- `yarn workspace @sourceacademy/bundle-binary_tree run test` — 16/16 passing, against `@sourceacademy/modules-testplugin`'s `TestDataHandler`
- `yarn workspace @sourceacademy/bundle-binary_tree run build` — produces `build/bundles/binary_tree.js`
- End-to-end: loaded the built bundle into py-slang's `PyCseEvaluator` (via py-slang#217's module loader work) and drove `make_tree`/`entry`/`left_branch`/`right_branch`/`is_tree` from real Python-shaped values through the actual `pythonToModule`/`moduleToPython` conversion code — all round-trip correctly.

## Notes for reviewers

Getting the end-to-end test working surfaced two bugs upstream of this PR, not fixable within `binary_tree` itself:
- `BaseModulePlugin.initialise()` in `conductor` registers each exported method as a detached function reference (`this[name]`) without binding it to the instance, so `this` is `undefined` inside any exported method body once a real evaluator calls it. This breaks every Conductor module that uses ordinary class methods (i.e. all of them), not just this one. Filing a fix against `conductor` separately.
- `moduleToPython`/`pythonToModule` in py-slang#217 flatten a returned `DataType.PAIR` into a Python list and convert Python lists back to `DataType.ARRAY`, which loses identity for any function returning a Pair that's meant to be passed back into another module call (e.g. `left_branch(t)`). Flagging this on that PR directly since the affected file is new there.