### PR TITLE
Migrate midi module to Conductor

### DIFF
--- a/src/bundles/midi/package.json
+++ b/src/bundles/midi/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "version": "1.0.0",
   "devDependencies": {
+    "@sourceacademy/conductor": "https://github.com/source-academy/conductor",
     "@sourceacademy/modules-buildtools": "workspace:^",
+    "@sourceacademy/modules-testplugin": "workspace:^",
     "typescript": "^6.0.2"
   },
   "dependencies": {

--- a/src/bundles/midi/package.json
+++ b/src/bundles/midi/package.json
@@ -3,12 +3,12 @@
   "private": true,
   "version": "1.0.0",
   "devDependencies": {
-    "@sourceacademy/conductor": "https://github.com/source-academy/conductor",
     "@sourceacademy/modules-buildtools": "workspace:^",
     "@sourceacademy/modules-testplugin": "workspace:^",
     "typescript": "^6.0.2"
   },
   "dependencies": {
+    "@sourceacademy/conductor": "https://github.com/source-academy/conductor",
     "js-slang": "^1.0.85"
   },
   "type": "module",

--- a/src/bundles/midi/src/__tests__/functions.test.ts
+++ b/src/bundles/midi/src/__tests__/functions.test.ts
@@ -1,31 +1,31 @@
 import { list_to_vector } from 'js-slang/dist/stdlib/list';
 import { describe, expect, test } from 'vitest';
-import { letter_name_to_midi_note, major_scale, midi_note_to_letter_name, minor_scale } from '../functions';
+import * as funcs from '../functions';
 import { Accidental, type Note, type NoteWithOctave } from '../types';
 import { noteToValues } from '../utils';
 
 describe('scales', () => {
   test('major_scale', () => {
-    const c0 = letter_name_to_midi_note('C0');
-    const scale = major_scale(c0);
+    const c0 = funcs.letter_name_to_midi_note('C0');
+    const scale = funcs.major_scale(c0);
     expect(list_to_vector(scale)).toMatchObject([12, 14, 16, 17, 19, 21, 23, 24]);
   });
 
   test('minor_scale', () => {
-    const a0 = letter_name_to_midi_note('A0');
-    const scale = minor_scale(a0);
+    const a0 = funcs.letter_name_to_midi_note('A0');
+    const scale = funcs.minor_scale(a0);
     expect(list_to_vector(scale)).toMatchObject([21, 23, 24, 26, 28, 29, 31, 33]);
   });
 });
 
-describe(midi_note_to_letter_name, () => {
+describe(funcs.midi_note_to_letter_name, () => {
   describe('Test with sharps', () => {
     test.each([
       [12, 'C0'],
       [13, 'C#0'],
       [36, 'C2'],
       [69, 'A4'],
-    ] as [number, NoteWithOctave][])('%i should equal %s', (note, noteName) => expect(midi_note_to_letter_name(note, 'sharp')).toEqual(noteName));
+    ] as [number, NoteWithOctave][])('%i should equal %s', (note, noteName) => expect(funcs.midi_note_to_letter_name(note, Accidental.SHARP)).toEqual(noteName));
   });
 
   describe('Test with flats', () => {
@@ -34,7 +34,7 @@ describe(midi_note_to_letter_name, () => {
       [13, 'Db0'],
       [36, 'C2'],
       [69, 'A4'],
-    ] as [number, NoteWithOctave][])('%i should equal %s', (note, noteName) => expect(midi_note_to_letter_name(note, 'flat')).toEqual(noteName));
+    ] as [number, NoteWithOctave][])('%i should equal %s', (note, noteName) => expect(funcs.midi_note_to_letter_name(note, Accidental.FLAT)).toEqual(noteName));
   });
 });
 
@@ -48,13 +48,72 @@ describe(noteToValues, () => {
     // Leaving out octave should set it to 4 automatically
     ['a', 'A', Accidental.NATURAL, 4]
   ] as [NoteWithOctave, Note, Accidental, number][])('%s', (note, expectedNote, expectedAccidental, expectedOctave) => {
-    const [actualNote, actualAccidental, actualOctave] = noteToValues(note);
+    const [actualNote, actualAccidental, actualOctave] = noteToValues(note, '');
     expect(actualNote).toEqual(expectedNote);
     expect(actualAccidental).toEqual(expectedAccidental);
     expect(actualOctave).toEqual(expectedOctave);
   });
 
   test('Invalid note should throw an error', () => {
-    expect(() => noteToValues('Fb9' as any)).toThrowError('noteToValues: Invalid Note with Octave: Fb9');
+    expect(() => noteToValues('Fb9' as any, 'noteToValues')).toThrow('noteToValues: Invalid Note with Octave: Fb9');
+  });
+});
+
+describe(funcs.add_octave_to_note, () => {
+  test('Valid note and octave', () => {
+    expect(funcs.add_octave_to_note('C', 4)).toEqual('C4');
+    expect(funcs.add_octave_to_note('F#', 0)).toEqual('F#0');
+  });
+
+  test('Invalid octave should throw an error', () => {
+    expect(() => funcs.add_octave_to_note('C', -1)).toThrow('add_octave_to_note: Expected integer ≥ 0 for octave, got -1.');
+    expect(() => funcs.add_octave_to_note('C', 2.5)).toThrow('add_octave_to_note: Expected integer ≥ 0 for octave, got 2.5.');
+  });
+});
+
+describe(funcs.get_octave, () => {
+  test('Valid note with octave', () => {
+    expect(funcs.get_octave('C4')).toEqual(4);
+    expect(funcs.get_octave('F#0')).toEqual(0);
+
+    // If octave is left out, it should default to 4
+    expect(funcs.get_octave('F')).toEqual(4);
+  });
+
+  test('Invalid note should throw an error', () => {
+    expect(() => funcs.get_octave('Fb9' as any)).toThrow('get_octave: Invalid Note with Octave: Fb9');
+  });
+});
+
+describe(funcs.key_signature_to_key, () => {
+  test('Valid key signatures', () => {
+    expect(funcs.key_signature_to_key(Accidental.SHARP, 0)).toEqual('C');
+    expect(funcs.key_signature_to_key(Accidental.SHARP, 2)).toEqual('D');
+    expect(funcs.key_signature_to_key(Accidental.FLAT, 3)).toEqual('Eb');
+  });
+
+  test('Invalid number of accidentals should throw an error', () => {
+    expect(() => funcs.key_signature_to_key(Accidental.SHARP, -1)).toThrow('key_signature_to_key: Expected integer ∈ [0, 6] for numAccidentals, got -1.');
+    expect(() => funcs.key_signature_to_key(Accidental.SHARP, 7)).toThrow('key_signature_to_key: Expected integer ∈ [0, 6] for numAccidentals, got 7.');
+    expect(() => funcs.key_signature_to_key(Accidental.SHARP, 2.5)).toThrow('key_signature_to_key: Expected integer ∈ [0, 6] for numAccidentals, got 2.5.');
+  });
+
+  test('Invalid accidental should throw an error', () => {
+    expect(() => funcs.key_signature_to_key('invalid' as any, 2)).toThrow('key_signature_to_key: Expected sharp or flat for accidental, got "invalid".');
+  });
+});
+
+describe(funcs.is_note_with_octave, () => {
+  test('Valid NoteWithOctaves', () => {
+    expect(funcs.is_note_with_octave('C4')).toBe(true);
+    expect(funcs.is_note_with_octave('F#0')).toBe(true);
+    expect(funcs.is_note_with_octave('Ab9')).toBe(true);
+    expect(funcs.is_note_with_octave('C')).toBe(true);
+    expect(funcs.is_note_with_octave('F#')).toBe(true);
+  });
+
+  test('Invalid NoteWithOctaves', () => {
+    expect(funcs.is_note_with_octave('Invalid')).toBe(false);
+    expect(funcs.is_note_with_octave(123)).toBe(false);
   });
 });

--- a/src/bundles/midi/src/__tests__/functions.test.ts
+++ b/src/bundles/midi/src/__tests__/functions.test.ts
@@ -1,0 +1,60 @@
+import { list_to_vector } from 'js-slang/dist/stdlib/list';
+import { describe, expect, test } from 'vitest';
+import { letter_name_to_midi_note, major_scale, midi_note_to_letter_name, minor_scale } from '../functions';
+import { Accidental, type Note, type NoteWithOctave } from '../types';
+import { noteToValues } from '../utils';
+
+describe('scales', () => {
+  test('major_scale', () => {
+    const c0 = letter_name_to_midi_note('C0');
+    const scale = major_scale(c0);
+    expect(list_to_vector(scale)).toMatchObject([12, 14, 16, 17, 19, 21, 23, 24]);
+  });
+
+  test('minor_scale', () => {
+    const a0 = letter_name_to_midi_note('A0');
+    const scale = minor_scale(a0);
+    expect(list_to_vector(scale)).toMatchObject([21, 23, 24, 26, 28, 29, 31, 33]);
+  });
+});
+
+describe(midi_note_to_letter_name, () => {
+  describe('Test with sharps', () => {
+    test.each([
+      [12, 'C0'],
+      [13, 'C#0'],
+      [36, 'C2'],
+      [69, 'A4'],
+    ] as [number, NoteWithOctave][])('%i should equal %s', (note, noteName) => expect(midi_note_to_letter_name(note, 'sharp')).toEqual(noteName));
+  });
+
+  describe('Test with flats', () => {
+    test.each([
+      [12, 'C0'],
+      [13, 'Db0'],
+      [36, 'C2'],
+      [69, 'A4'],
+    ] as [number, NoteWithOctave][])('%i should equal %s', (note, noteName) => expect(midi_note_to_letter_name(note, 'flat')).toEqual(noteName));
+  });
+});
+
+describe(noteToValues, () => {
+  test.each([
+    ['C0', 'C', Accidental.NATURAL, 0],
+    ['C3', 'C', Accidental.NATURAL, 3],
+    ['F#12', 'F', Accidental.SHARP, 12],
+    ['Ab9', 'A', Accidental.FLAT, 9],
+    ['Bb4', 'B', Accidental.FLAT, 4],
+    // Leaving out octave should set it to 4 automatically
+    ['a', 'A', Accidental.NATURAL, 4]
+  ] as [NoteWithOctave, Note, Accidental, number][])('%s', (note, expectedNote, expectedAccidental, expectedOctave) => {
+    const [actualNote, actualAccidental, actualOctave] = noteToValues(note);
+    expect(actualNote).toEqual(expectedNote);
+    expect(actualAccidental).toEqual(expectedAccidental);
+    expect(actualOctave).toEqual(expectedOctave);
+  });
+
+  test('Invalid note should throw an error', () => {
+    expect(() => noteToValues('Fb9' as any)).toThrowError('noteToValues: Invalid Note with Octave: Fb9');
+  });
+});

--- a/src/bundles/midi/src/__tests__/index.test.ts
+++ b/src/bundles/midi/src/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { DataType, type TypedValue } from '@sourceacademy/conductor/types';
 import { TestDataHandler } from '@sourceacademy/modules-testplugin';
 import { list, type List } from 'js-slang/dist/stdlib/list';
 import { describe, expect, it } from 'vitest';
-import { assertAccidental, scaleToConductorList } from '../conductorAdapters';
+import { scaleToConductorList } from '../conductorAdapters';
 
 describe(scaleToConductorList, () => {
   it('converts an empty js-slang list to a Conductor empty list', async () => {
@@ -17,17 +17,6 @@ describe(scaleToConductorList, () => {
     const conductorList = await scaleToConductorList(handler, jsList);
     const values = await handler.list_to_vec(conductorList as TypedValue<DataType.LIST>);
     expect(values.map(v => v.value)).toEqual([12, 14, 16]);
-  });
-});
-
-describe(assertAccidental, () => {
-  it('accepts "flat" and "sharp"', () => {
-    expect(() => assertAccidental('flat', 'test')).not.toThrow();
-    expect(() => assertAccidental('sharp', 'test')).not.toThrow();
-  });
-
-  it('rejects anything else', () => {
-    expect(() => assertAccidental('natural', 'my_func')).toThrowError("my_func expects 'flat' or 'sharp'");
   });
 });
 

--- a/src/bundles/midi/src/__tests__/index.test.ts
+++ b/src/bundles/midi/src/__tests__/index.test.ts
@@ -1,61 +1,41 @@
-import { list_to_vector } from 'js-slang/dist/stdlib/list';
-import { describe, expect, test } from 'vitest';
-import { letter_name_to_midi_note, midi_note_to_letter_name } from '..';
-import { major_scale, minor_scale } from '../scales';
-import { Accidental, type Note, type NoteWithOctave } from '../types';
-import { noteToValues } from '../utils';
+import { DataType, type TypedValue } from '@sourceacademy/conductor/types';
+import { TestDataHandler } from '@sourceacademy/modules-testplugin';
+import { list, type List } from 'js-slang/dist/stdlib/list';
+import { describe, expect, it } from 'vitest';
+import { assertAccidental, scaleToConductorList } from '../conductorAdapters';
 
-describe('scales', () => {
-  test('major_scale', () => {
-    const c0 = letter_name_to_midi_note('C0');
-    const scale = major_scale(c0);
-    expect(list_to_vector(scale)).toMatchObject([12, 14, 16, 17, 19, 21, 23, 24]);
+describe(scaleToConductorList, () => {
+  it('converts an empty js-slang list to a Conductor empty list', async () => {
+    const handler = new TestDataHandler();
+    const result = await scaleToConductorList(handler, null);
+    expect(result.type).toEqual(DataType.EMPTY_LIST);
   });
 
-  test('minor_scale', () => {
-    const a0 = letter_name_to_midi_note('A0');
-    const scale = minor_scale(a0);
-    expect(list_to_vector(scale)).toMatchObject([21, 23, 24, 26, 28, 29, 31, 33]);
-  });
-});
-
-describe(midi_note_to_letter_name, () => {
-  describe('Test with sharps', () => {
-    test.each([
-      [12, 'C0'],
-      [13, 'C#0'],
-      [36, 'C2'],
-      [69, 'A4'],
-    ] as [number, NoteWithOctave][])('%i should equal %s', (note, noteName) => expect(midi_note_to_letter_name(note, 'sharp')).toEqual(noteName));
-  });
-
-  describe('Test with flats', () => {
-    test.each([
-      [12, 'C0'],
-      [13, 'Db0'],
-      [36, 'C2'],
-      [69, 'A4'],
-    ] as [number, NoteWithOctave][])('%i should equal %s', (note, noteName) => expect(midi_note_to_letter_name(note, 'flat')).toEqual(noteName));
+  it('converts a js-slang list of numbers into a real Conductor list', async () => {
+    const handler = new TestDataHandler();
+    const jsList: List = list(12, 14, 16);
+    const conductorList = await scaleToConductorList(handler, jsList);
+    const values = await handler.list_to_vec(conductorList as TypedValue<DataType.LIST>);
+    expect(values.map(v => v.value)).toEqual([12, 14, 16]);
   });
 });
 
-describe(noteToValues, () => {
-  test.each([
-    ['C0', 'C', Accidental.NATURAL, 0],
-    ['C3', 'C', Accidental.NATURAL, 3],
-    ['F#12', 'F', Accidental.SHARP, 12],
-    ['Ab9', 'A', Accidental.FLAT, 9],
-    ['Bb4', 'B', Accidental.FLAT, 4],
-    // Leaving out octave should set it to 4 automatically
-    ['a', 'A', Accidental.NATURAL, 4]
-  ] as [NoteWithOctave, Note, Accidental, number][])('%s', (note, expectedNote, expectedAccidental, expectedOctave) => {
-    const [actualNote, actualAccidental, actualOctave] = noteToValues(note);
-    expect(actualNote).toEqual(expectedNote);
-    expect(actualAccidental).toEqual(expectedAccidental);
-    expect(actualOctave).toEqual(expectedOctave);
+describe(assertAccidental, () => {
+  it('accepts "flat" and "sharp"', () => {
+    expect(() => assertAccidental('flat', 'test')).not.toThrow();
+    expect(() => assertAccidental('sharp', 'test')).not.toThrow();
   });
 
-  test('Invalid note should throw an error', () => {
-    expect(() => noteToValues('Fb9' as any)).toThrowError('noteToValues: Invalid Note with Octave: Fb9');
+  it('rejects anything else', () => {
+    expect(() => assertAccidental('natural', 'my_func')).toThrowError("my_func expects 'flat' or 'sharp'");
+  });
+});
+
+describe('exported constants shape', () => {
+  it('SHARP/FLAT/NATURAL are single-character strings', async () => {
+    const { SHARP, FLAT, NATURAL } = await import('../functions');
+    expect(SHARP).toEqual('#');
+    expect(FLAT).toEqual('b');
+    expect(NATURAL).toEqual('♮');
   });
 });

--- a/src/bundles/midi/src/conductorAdapters.ts
+++ b/src/bundles/midi/src/conductorAdapters.ts
@@ -1,0 +1,21 @@
+/**
+ * Plain helpers used by the Conductor plugin in index.ts, kept in their own undecorated file so
+ * they stay importable from vitest — a test file that imports index.ts directly hits a decorator
+ * syntax error there (vitest's transform doesn't apply the same decorator settings tsc does).
+ */
+import { EvaluatorTypeError } from '@sourceacademy/conductor/common';
+import { DataType, type IDataHandler, type TypedValue } from '@sourceacademy/conductor/types';
+import { mEmptyList } from '@sourceacademy/conductor/util';
+import type { List } from 'js-slang/dist/stdlib/list';
+
+export async function scaleToConductorList(evaluator: IDataHandler, scale: List): Promise<TypedValue<DataType.LIST>> {
+  if (scale === null) return mEmptyList();
+  const [head, tail] = scale;
+  return evaluator.pair_make({ type: DataType.NUMBER, value: head }, await scaleToConductorList(evaluator, tail));
+}
+
+export function assertAccidental(value: string, funcName: string): asserts value is 'flat' | 'sharp' {
+  if (value !== 'flat' && value !== 'sharp') {
+    throw new EvaluatorTypeError(`${funcName} expects 'flat' or 'sharp'`, "'flat' | 'sharp'", `'${value}'`);
+  }
+}

--- a/src/bundles/midi/src/conductorAdapters.ts
+++ b/src/bundles/midi/src/conductorAdapters.ts
@@ -3,7 +3,6 @@
  * they stay importable from vitest — a test file that imports index.ts directly hits a decorator
  * syntax error there (vitest's transform doesn't apply the same decorator settings tsc does).
  */
-import { EvaluatorTypeError } from '@sourceacademy/conductor/common';
 import { DataType, type IDataHandler, type TypedValue } from '@sourceacademy/conductor/types';
 import { mEmptyList } from '@sourceacademy/conductor/util';
 import type { List } from 'js-slang/dist/stdlib/list';
@@ -12,10 +11,4 @@ export async function scaleToConductorList(evaluator: IDataHandler, scale: List)
   if (scale === null) return mEmptyList();
   const [head, tail] = scale;
   return evaluator.pair_make({ type: DataType.NUMBER, value: head }, await scaleToConductorList(evaluator, tail));
-}
-
-export function assertAccidental(value: string, funcName: string): asserts value is 'flat' | 'sharp' {
-  if (value !== 'flat' && value !== 'sharp') {
-    throw new EvaluatorTypeError(`${funcName} expects 'flat' or 'sharp'`, "'flat' | 'sharp'", `'${value}'`);
-  }
 }

--- a/src/bundles/midi/src/functions.ts
+++ b/src/bundles/midi/src/functions.ts
@@ -1,0 +1,130 @@
+/**
+ * Pure, evaluator-free implementations of the MIDI bundle's functions. Kept separate from the
+ * Conductor-facing `index.ts` plugin because other bundles (`sound`, `stereo_sound`) import these
+ * directly as plain TypeScript, not through Conductor's TypedValue/IDataHandler boundary.
+ *
+ * @module MIDI
+ * @author leeyi45
+ */
+
+import { Accidental, type MIDINote, type NoteWithOctave } from './types';
+import { midiNoteToNoteName, noteToValues } from './utils';
+
+/**
+ * Converts a letter name to its corresponding MIDI note.
+ * The letter name is represented in standard pitch notation.
+ * Examples are "A5", "Db3", "C#7".
+ * Refer to [this](https://i.imgur.com/qGQgmYr.png) mapping from
+ * letter name to midi notes.
+ *
+ * @param note given letter name
+ * @returns the corresponding midi note
+ * @example
+ * ```
+ * letter_name_to_midi_note('C4'); // Returns 60
+ * ```
+ * @function
+ */
+export function letter_name_to_midi_note(note: NoteWithOctave): MIDINote {
+  const [noteName, accidental, octave] = noteToValues(note, letter_name_to_midi_note.name);
+
+  let res = 12; // C0 is midi note 12
+  switch (noteName) {
+    case 'C':
+      break;
+    case 'D':
+      res += 2;
+      break;
+
+    case 'E':
+      res += 4;
+      break;
+
+    case 'F':
+      res += 5;
+      break;
+
+    case 'G':
+      res += 7;
+      break;
+
+    case 'A':
+      res += 9;
+      break;
+
+    case 'B':
+      res += 11;
+      break;
+
+    default:
+      break;
+  }
+
+  switch (accidental) {
+    case Accidental.FLAT: {
+      res -= 1;
+      break;
+    }
+    case Accidental.SHARP: {
+      res += 1;
+      break;
+    }
+    case Accidental.NATURAL:
+      break;
+  }
+
+  return res + 12 * octave;
+}
+
+/**
+ * Convert a MIDI note into its letter representation
+ * @param midiNote Note to convert
+ * @param accidental Whether to return the letter as with a sharp or with a flat
+ * @function
+ */
+export function midi_note_to_letter_name(midiNote: MIDINote, accidental: 'flat' | 'sharp'): NoteWithOctave {
+  const octave = Math.floor(midiNote / 12) - 1;
+  const note = midiNoteToNoteName(midiNote, accidental, midi_note_to_letter_name.name);
+  return `${note}${octave}`;
+}
+
+/**
+ * Converts a MIDI note to its corresponding frequency.
+ *
+ * @param note given MIDI note
+ * @returns the frequency of the MIDI note
+ * @function
+ * @example midi_note_to_frequency(69); // Returns 440
+ */
+export function midi_note_to_frequency(note: MIDINote): number {
+  // A4 = 440Hz = midi note 69
+  return 440 * 2 ** ((note - 69) / 12);
+}
+
+/**
+ * Converts a letter name to its corresponding frequency.
+ *
+ * @param note given letter name
+ * @returns the corresponding frequency
+ * @example letter_name_to_frequency("A4"); // Returns 440
+ */
+export function letter_name_to_frequency(note: NoteWithOctave): number {
+  return midi_note_to_frequency(letter_name_to_midi_note(note));
+}
+
+export * from './scales';
+
+/**
+ * String representing the sharp symbol '#'
+ */
+export const SHARP = Accidental.SHARP;
+
+/**
+ * String representing the flat symbol 'b'
+ */
+export const FLAT = Accidental.FLAT;
+
+/**
+ * String representing the natural symbol '♮'
+ */
+export const NATURAL = Accidental.NATURAL;

--- a/src/bundles/midi/src/functions.ts
+++ b/src/bundles/midi/src/functions.ts
@@ -26,7 +26,7 @@ import { midiNoteToNoteName, noteToValues } from './utils';
  * @function
  */
 export function letter_name_to_midi_note(note: NoteWithOctave): MIDINote {
-  const [noteName, accidental, octave] = noteToValues(note, letter_name_to_midi_note.name);
+  const [noteName, accidental, octave] = noteToValues(note, 'letter_name_to_midi_note');
 
   let res = 12; // C0 is midi note 12
   switch (noteName) {
@@ -84,7 +84,7 @@ export function letter_name_to_midi_note(note: NoteWithOctave): MIDINote {
  */
 export function midi_note_to_letter_name(midiNote: MIDINote, accidental: 'flat' | 'sharp'): NoteWithOctave {
   const octave = Math.floor(midiNote / 12) - 1;
-  const note = midiNoteToNoteName(midiNote, accidental, midi_note_to_letter_name.name);
+  const note = midiNoteToNoteName(midiNote, accidental, 'midi_note_to_letter_name');
   return `${note}${octave}`;
 }
 

--- a/src/bundles/midi/src/functions.ts
+++ b/src/bundles/midi/src/functions.ts
@@ -7,8 +7,17 @@
  * @author leeyi45
  */
 
-import { Accidental, type MIDINote, type NoteWithOctave } from './types';
-import { midiNoteToNoteName, noteToValues } from './utils';
+import { EvaluatorParameterTypeError, assertNumberWithinRange } from '@sourceacademy/conductor/common';
+import { Accidental, type MIDINote, type Note, type NoteWithOctave } from './types';
+import { midiNoteToNoteName, noteToValues, parseNoteWithOctave } from './utils';
+
+/**
+ * Returns a boolean value indicating whether the given value is a {@link NoteWithOctave|note name with octave}.
+ * @function
+ */
+export function is_note_with_octave(value: unknown): value is NoteWithOctave {
+  return parseNoteWithOctave(value) !== null;
+}
 
 /**
  * Converts a letter name to its corresponding MIDI note.
@@ -77,39 +86,128 @@ export function letter_name_to_midi_note(note: NoteWithOctave): MIDINote {
 }
 
 /**
- * Convert a MIDI note into its letter representation
+ * Convert a {@link MIDINote|MIDI note} into its {@link NoteWithOctave|letter representation}
+ *
  * @param midiNote Note to convert
  * @param accidental Whether to return the letter as with a sharp or with a flat
  * @function
+ * @example
+ * ```
+ * midi_note_to_letter_name(61, SHARP); // Returns "C#4"
+ * midi_note_to_letter_name(61, FLAT);  // Returns "Db4"
+ *
+ * // Notes without accidentals return the same letter name
+ * // regardless of whether SHARP or FLAT is passed in
+ * midi_note_to_letter_name(60, FLAT);  // Returns "C4"
+ * midi_note_to_letter_name(60, SHARP); // Returns "C4"
+ * ```
  */
-export function midi_note_to_letter_name(midiNote: MIDINote, accidental: 'flat' | 'sharp'): NoteWithOctave {
+export function midi_note_to_letter_name(midiNote: MIDINote, accidental: Accidental.FLAT | Accidental.SHARP): NoteWithOctave {
   const octave = Math.floor(midiNote / 12) - 1;
   const note = midiNoteToNoteName(midiNote, accidental, 'midi_note_to_letter_name');
   return `${note}${octave}`;
 }
 
 /**
- * Converts a MIDI note to its corresponding frequency.
+ * Converts a {@link MIDINote|MIDI note} to its corresponding frequency.
  *
  * @param note given MIDI note
  * @returns the frequency of the MIDI note
  * @function
- * @example midi_note_to_frequency(69); // Returns 440
+ * @example
+ * ```
+ * midi_note_to_frequency(69); // Returns 440
+ * ```
  */
 export function midi_note_to_frequency(note: MIDINote): number {
+  assertNumberWithinRange(note, 'midi_note_to_frequency');
   // A4 = 440Hz = midi note 69
   return 440 * 2 ** ((note - 69) / 12);
 }
 
 /**
- * Converts a letter name to its corresponding frequency.
+ * Converts a {@link NoteWithOctave|note name} to its corresponding frequency.
  *
  * @param note given letter name
- * @returns the corresponding frequency
- * @example letter_name_to_frequency("A4"); // Returns 440
+ * @returns the corresponding frequency (in Hz)
+ * @example
+ * ```
+ * letter_name_to_frequency('A4'); // Returns 440
+ * ```
  */
 export function letter_name_to_frequency(note: NoteWithOctave): number {
   return midi_note_to_frequency(letter_name_to_midi_note(note));
+}
+
+/**
+ * Takes the given {@link Note} and adds the octave number to it.
+ * @function
+ * @example
+ * ```
+ * add_octave_to_note('C', 4); // Returns "C4"
+ * ```
+ */
+export function add_octave_to_note(note: Note, octave: number): NoteWithOctave {
+  assertNumberWithinRange(octave, 'add_octave_to_note', 0, undefined, true, 'octave');
+  return `${note}${octave}`;
+}
+
+/**
+ * Gets the octave number from a given {@link NoteWithOctave|note name with octave}.
+ * @function
+ */
+export function get_octave(note: NoteWithOctave): number {
+  const [, , octave] = noteToValues(note, 'get_octave');
+  return octave;
+}
+
+/**
+ * Gets the letter name from a given {@link NoteWithOctave|note name with octave} (without the accidental).
+ * @function
+ * @example
+ * ```
+ * get_note_name('C#4'); // Returns "C"
+ * get_note_name('Eb3'); // Returns "E"
+ * ```
+ */
+export function get_note_name(note: NoteWithOctave): Note {
+  const [noteName] = noteToValues(note, 'get_note_name');
+  return noteName;
+}
+
+/**
+ * Gets the accidental from a given {@link NoteWithOctave|note name with octave}.
+ * @function
+ */
+export function get_accidental(note: NoteWithOctave): Accidental {
+  const [, accidental] = noteToValues(note, 'get_accidental');
+  return accidental;
+}
+
+/**
+ * Converts the key signature to the corresponding key
+ * @function
+ * @example
+ * ```
+ * key_signature_to_key(SHARP, 2); // Returns "D", since the key of D has 2 sharps
+ * key_signature_to_key(FLAT, 3); // Returns "Eb", since the key of Eb has 3 flats
+ * ```
+ */
+export function key_signature_to_key(accidental: Accidental.FLAT | Accidental.SHARP, numAccidentals: number): Note {
+  assertNumberWithinRange(numAccidentals, 'key_signature_to_key', 0, 6, true, 'numAccidentals');
+
+  switch (accidental) {
+    case Accidental.SHARP: {
+      const keys: Note[] = ['C', 'G', 'D', 'A', 'E', 'B', 'F#'];
+      return keys[numAccidentals];
+    }
+    case Accidental.FLAT: {
+      const keys: Note[] = ['C', 'F', 'Bb', 'Eb', 'Ab', 'Db', 'Gb'];
+      return keys[numAccidentals];
+    }
+    default:
+      throw new EvaluatorParameterTypeError('key_signature_to_key', 'accidental', 'sharp or flat', accidental);
+  }
 }
 
 export * from './scales';

--- a/src/bundles/midi/src/index.ts
+++ b/src/bundles/midi/src/index.ts
@@ -5,125 +5,146 @@
  * @module MIDI
  * @author leeyi45
  */
+import type { IChannel, IConduit } from '@sourceacademy/conductor/conduit';
+import { BaseModulePlugin, moduleMethod } from '@sourceacademy/conductor/module';
+import type { IInterfacableEvaluator } from '@sourceacademy/conductor/runner';
+import { DataType, type IFunctionSignature, type TypedValue } from '@sourceacademy/conductor/types';
 
-import { Accidental, type MIDINote, type NoteWithOctave } from './types';
-import { midiNoteToNoteName, noteToValues } from './utils';
+import { assertAccidental, scaleToConductorList } from './conductorAdapters';
+import {
+  FLAT,
+  NATURAL,
+  SHARP,
+  aeolian_scale as aeolian_scale_func,
+  dorian_scale as dorian_scale_func,
+  ionian_scale as ionian_scale_func,
+  letter_name_to_frequency as letter_name_to_frequency_func,
+  letter_name_to_midi_note as letter_name_to_midi_note_func,
+  locrian_scale as locrian_scale_func,
+  lydian_scale as lydian_scale_func,
+  major_scale as major_scale_func,
+  midi_note_to_frequency as midi_note_to_frequency_func,
+  midi_note_to_letter_name as midi_note_to_letter_name_func,
+  minor_scale as minor_scale_func,
+  mixolydian_scale as mixolydian_scale_func,
+  phrygian_scale as phrygian_scale_func
+} from './functions';
+import type { MIDINote, NoteWithOctave } from './types';
 
-/**
- * Converts a letter name to its corresponding MIDI note.
- * The letter name is represented in standard pitch notation.
- * Examples are "A5", "Db3", "C#7".
- * Refer to [this](https://i.imgur.com/qGQgmYr.png) mapping from
- * letter name to midi notes.
- *
- * @param note given letter name
- * @returns the corresponding midi note
- * @example
- * ```
- * letter_name_to_midi_note('C4'); // Returns 60
- * ```
- * @function
- */
-export function letter_name_to_midi_note(note: NoteWithOctave): MIDINote {
-  const [noteName, accidental, octave] = noteToValues(note, letter_name_to_midi_note.name);
-
-  let res = 12; // C0 is midi note 12
-  switch (noteName) {
-    case 'C':
-      break;
-    case 'D':
-      res += 2;
-      break;
-
-    case 'E':
-      res += 4;
-      break;
-
-    case 'F':
-      res += 5;
-      break;
-
-    case 'G':
-      res += 7;
-      break;
-
-    case 'A':
-      res += 9;
-      break;
-
-    case 'B':
-      res += 11;
-      break;
-
-    default:
-      break;
+export default class MidiModulePlugin extends BaseModulePlugin {
+  id = 'midi';
+  exportedNames = [
+    'letter_name_to_midi_note',
+    'midi_note_to_letter_name',
+    'midi_note_to_frequency',
+    'letter_name_to_frequency',
+    'major_scale',
+    'ionian_scale',
+    'dorian_scale',
+    'phrygian_scale',
+    'lydian_scale',
+    'mixolydian_scale',
+    'minor_scale',
+    'aeolian_scale',
+    'locrian_scale'
+  ] as const;
+  static channelAttach = [];
+  constructor(conduit: IConduit, channels: IChannel<any>[], evaluator: IInterfacableEvaluator) {
+    super(conduit, channels, evaluator);
+    this.__bindExportedMethods();
+    // BaseModulePlugin.initialise() only registers exportedNames whose value is a function, so
+    // these plain string constants are pushed onto `exports` directly instead.
+    this.exports.push(
+      { symbol: 'SHARP', value: { type: DataType.CONST_STRING, value: SHARP } },
+      { symbol: 'FLAT', value: { type: DataType.CONST_STRING, value: FLAT } },
+      { symbol: 'NATURAL', value: { type: DataType.CONST_STRING, value: NATURAL } }
+    );
   }
 
-  switch (accidental) {
-    case Accidental.FLAT: {
-      res -= 1;
-      break;
+  // See binary_tree's index.ts / source-academy/conductor#41 for why this is needed: evaluators
+  // call the registered closure as a bare function, so `this` inside the method body is
+  // undefined unless bound to the instance first.
+  private __bindExportedMethods() {
+    for (const name of this.exportedNames) {
+      const method = this[name];
+      if (typeof method !== 'function') continue;
+
+      const signature = (method as { signature?: IFunctionSignature<any, any> }).signature;
+      const boundMethod = method.bind(this) as typeof method & { signature?: IFunctionSignature<any, any> };
+      boundMethod.signature = signature;
+      Object.defineProperty(this, name, {
+        configurable: true,
+        value: boundMethod
+      });
     }
-    case Accidental.SHARP: {
-      res += 1;
-      break;
-    }
-    case Accidental.NATURAL:
-      break;
   }
 
-  return res + 12 * octave;
+  @moduleMethod([DataType.CONST_STRING], DataType.NUMBER)
+  async* letter_name_to_midi_note(note: TypedValue<DataType.CONST_STRING>): AsyncGenerator<void, TypedValue<DataType.NUMBER>, unknown> {
+    return { type: DataType.NUMBER, value: letter_name_to_midi_note_func(note.value as NoteWithOctave) };
+  }
+
+  @moduleMethod([DataType.NUMBER, DataType.CONST_STRING], DataType.CONST_STRING)
+  async* midi_note_to_letter_name(
+    note: TypedValue<DataType.NUMBER>,
+    accidental: TypedValue<DataType.CONST_STRING>
+  ): AsyncGenerator<void, TypedValue<DataType.CONST_STRING>, unknown> {
+    assertAccidental(accidental.value, midi_note_to_letter_name_func.name);
+    return { type: DataType.CONST_STRING, value: midi_note_to_letter_name_func(note.value as MIDINote, accidental.value) };
+  }
+
+  @moduleMethod([DataType.NUMBER], DataType.NUMBER)
+  async* midi_note_to_frequency(note: TypedValue<DataType.NUMBER>): AsyncGenerator<void, TypedValue<DataType.NUMBER>, unknown> {
+    return { type: DataType.NUMBER, value: midi_note_to_frequency_func(note.value as MIDINote) };
+  }
+
+  @moduleMethod([DataType.CONST_STRING], DataType.NUMBER)
+  async* letter_name_to_frequency(note: TypedValue<DataType.CONST_STRING>): AsyncGenerator<void, TypedValue<DataType.NUMBER>, unknown> {
+    return { type: DataType.NUMBER, value: letter_name_to_frequency_func(note.value as NoteWithOctave) };
+  }
+
+  @moduleMethod([DataType.NUMBER], DataType.LIST)
+  async* major_scale(key: TypedValue<DataType.NUMBER>): AsyncGenerator<void, TypedValue<DataType.LIST>, unknown> {
+    return await scaleToConductorList(this.evaluator, major_scale_func(key.value as MIDINote));
+  }
+
+  @moduleMethod([DataType.NUMBER], DataType.LIST)
+  async* ionian_scale(key: TypedValue<DataType.NUMBER>): AsyncGenerator<void, TypedValue<DataType.LIST>, unknown> {
+    return await scaleToConductorList(this.evaluator, ionian_scale_func(key.value as MIDINote));
+  }
+
+  @moduleMethod([DataType.NUMBER], DataType.LIST)
+  async* dorian_scale(key: TypedValue<DataType.NUMBER>): AsyncGenerator<void, TypedValue<DataType.LIST>, unknown> {
+    return await scaleToConductorList(this.evaluator, dorian_scale_func(key.value as MIDINote));
+  }
+
+  @moduleMethod([DataType.NUMBER], DataType.LIST)
+  async* phrygian_scale(key: TypedValue<DataType.NUMBER>): AsyncGenerator<void, TypedValue<DataType.LIST>, unknown> {
+    return await scaleToConductorList(this.evaluator, phrygian_scale_func(key.value as MIDINote));
+  }
+
+  @moduleMethod([DataType.NUMBER], DataType.LIST)
+  async* lydian_scale(key: TypedValue<DataType.NUMBER>): AsyncGenerator<void, TypedValue<DataType.LIST>, unknown> {
+    return await scaleToConductorList(this.evaluator, lydian_scale_func(key.value as MIDINote));
+  }
+
+  @moduleMethod([DataType.NUMBER], DataType.LIST)
+  async* mixolydian_scale(key: TypedValue<DataType.NUMBER>): AsyncGenerator<void, TypedValue<DataType.LIST>, unknown> {
+    return await scaleToConductorList(this.evaluator, mixolydian_scale_func(key.value as MIDINote));
+  }
+
+  @moduleMethod([DataType.NUMBER], DataType.LIST)
+  async* minor_scale(key: TypedValue<DataType.NUMBER>): AsyncGenerator<void, TypedValue<DataType.LIST>, unknown> {
+    return await scaleToConductorList(this.evaluator, minor_scale_func(key.value as MIDINote));
+  }
+
+  @moduleMethod([DataType.NUMBER], DataType.LIST)
+  async* aeolian_scale(key: TypedValue<DataType.NUMBER>): AsyncGenerator<void, TypedValue<DataType.LIST>, unknown> {
+    return await scaleToConductorList(this.evaluator, aeolian_scale_func(key.value as MIDINote));
+  }
+
+  @moduleMethod([DataType.NUMBER], DataType.LIST)
+  async* locrian_scale(key: TypedValue<DataType.NUMBER>): AsyncGenerator<void, TypedValue<DataType.LIST>, unknown> {
+    return await scaleToConductorList(this.evaluator, locrian_scale_func(key.value as MIDINote));
+  }
 }
-
-/**
- * Convert a MIDI note into its letter representation
- * @param midiNote Note to convert
- * @param accidental Whether to return the letter as with a sharp or with a flat
- * @function
- */
-export function midi_note_to_letter_name(midiNote: MIDINote, accidental: 'flat' | 'sharp'): NoteWithOctave {
-  const octave = Math.floor(midiNote / 12) - 1;
-  const note = midiNoteToNoteName(midiNote, accidental, midi_note_to_letter_name.name);
-  return `${note}${octave}`;
-}
-
-/**
- * Converts a MIDI note to its corresponding frequency.
- *
- * @param note given MIDI note
- * @returns the frequency of the MIDI note
- * @function
- * @example midi_note_to_frequency(69); // Returns 440
- */
-export function midi_note_to_frequency(note: MIDINote): number {
-  // A4 = 440Hz = midi note 69
-  return 440 * 2 ** ((note - 69) / 12);
-}
-
-/**
- * Converts a letter name to its corresponding frequency.
- *
- * @param note given letter name
- * @returns the corresponding frequency
- * @example letter_name_to_frequency("A4"); // Returns 440
- */
-export function letter_name_to_frequency(note: NoteWithOctave): number {
-  return midi_note_to_frequency(letter_name_to_midi_note(note));
-}
-
-export * from './scales';
-
-/**
- * String representing the sharp symbol '#'
- */
-export const SHARP = Accidental.SHARP;
-
-/**
- * String representing the flat symbol 'b'
- */
-export const FLAT = Accidental.FLAT;
-
-/**
- * String representing the natural symbol '♮'
- */
-export const NATURAL = Accidental.NATURAL;

--- a/src/bundles/midi/src/index.ts
+++ b/src/bundles/midi/src/index.ts
@@ -10,14 +10,20 @@ import { BaseModulePlugin, moduleMethod } from '@sourceacademy/conductor/module'
 import type { IInterfacableEvaluator } from '@sourceacademy/conductor/runner';
 import { DataType, type IFunctionSignature, type TypedValue } from '@sourceacademy/conductor/types';
 
-import { assertAccidental, scaleToConductorList } from './conductorAdapters';
+import { scaleToConductorList } from './conductorAdapters';
 import {
   FLAT,
   NATURAL,
   SHARP,
+  add_octave_to_note as add_octave_to_note_func,
   aeolian_scale as aeolian_scale_func,
   dorian_scale as dorian_scale_func,
+  get_accidental as get_accidental_func,
+  get_note_name as get_note_name_func,
+  get_octave as get_octave_func,
   ionian_scale as ionian_scale_func,
+  is_note_with_octave as is_note_with_octave_func,
+  key_signature_to_key as key_signature_to_key_func,
   letter_name_to_frequency as letter_name_to_frequency_func,
   letter_name_to_midi_note as letter_name_to_midi_note_func,
   locrian_scale as locrian_scale_func,
@@ -29,7 +35,7 @@ import {
   mixolydian_scale as mixolydian_scale_func,
   phrygian_scale as phrygian_scale_func
 } from './functions';
-import type { MIDINote, NoteWithOctave } from './types';
+import type { Accidental, MIDINote, Note, NoteWithOctave } from './types';
 
 export default class MidiModulePlugin extends BaseModulePlugin {
   id = 'midi';
@@ -38,6 +44,12 @@ export default class MidiModulePlugin extends BaseModulePlugin {
     'midi_note_to_letter_name',
     'midi_note_to_frequency',
     'letter_name_to_frequency',
+    'is_note_with_octave',
+    'add_octave_to_note',
+    'get_octave',
+    'get_note_name',
+    'get_accidental',
+    'key_signature_to_key',
     'major_scale',
     'ionian_scale',
     'dorian_scale',
@@ -89,8 +101,10 @@ export default class MidiModulePlugin extends BaseModulePlugin {
     note: TypedValue<DataType.NUMBER>,
     accidental: TypedValue<DataType.CONST_STRING>
   ): AsyncGenerator<void, TypedValue<DataType.CONST_STRING>, unknown> {
-    assertAccidental(accidental.value, 'midi_note_to_letter_name');
-    return { type: DataType.CONST_STRING, value: midi_note_to_letter_name_func(note.value as MIDINote, accidental.value) };
+    return {
+      type: DataType.CONST_STRING,
+      value: midi_note_to_letter_name_func(note.value as MIDINote, accidental.value as Accidental.FLAT | Accidental.SHARP)
+    };
   }
 
   @moduleMethod([DataType.NUMBER], DataType.NUMBER)
@@ -101,6 +115,47 @@ export default class MidiModulePlugin extends BaseModulePlugin {
   @moduleMethod([DataType.CONST_STRING], DataType.NUMBER)
   async* letter_name_to_frequency(note: TypedValue<DataType.CONST_STRING>): AsyncGenerator<void, TypedValue<DataType.NUMBER>, unknown> {
     return { type: DataType.NUMBER, value: letter_name_to_frequency_func(note.value as NoteWithOctave) };
+  }
+
+  // No declared arg type: is_note_with_octave is a predicate that must accept a value of any
+  // Conductor DataType (not just strings) and answer false rather than throw.
+  @moduleMethod([], DataType.BOOLEAN)
+  async* is_note_with_octave(value?: TypedValue<DataType>): AsyncGenerator<void, TypedValue<DataType.BOOLEAN>, unknown> {
+    return { type: DataType.BOOLEAN, value: is_note_with_octave_func(value?.value) };
+  }
+
+  @moduleMethod([DataType.CONST_STRING, DataType.NUMBER], DataType.CONST_STRING)
+  async* add_octave_to_note(
+    note: TypedValue<DataType.CONST_STRING>,
+    octave: TypedValue<DataType.NUMBER>
+  ): AsyncGenerator<void, TypedValue<DataType.CONST_STRING>, unknown> {
+    return { type: DataType.CONST_STRING, value: add_octave_to_note_func(note.value as Note, octave.value) };
+  }
+
+  @moduleMethod([DataType.CONST_STRING], DataType.NUMBER)
+  async* get_octave(note: TypedValue<DataType.CONST_STRING>): AsyncGenerator<void, TypedValue<DataType.NUMBER>, unknown> {
+    return { type: DataType.NUMBER, value: get_octave_func(note.value as NoteWithOctave) };
+  }
+
+  @moduleMethod([DataType.CONST_STRING], DataType.CONST_STRING)
+  async* get_note_name(note: TypedValue<DataType.CONST_STRING>): AsyncGenerator<void, TypedValue<DataType.CONST_STRING>, unknown> {
+    return { type: DataType.CONST_STRING, value: get_note_name_func(note.value as NoteWithOctave) };
+  }
+
+  @moduleMethod([DataType.CONST_STRING], DataType.CONST_STRING)
+  async* get_accidental(note: TypedValue<DataType.CONST_STRING>): AsyncGenerator<void, TypedValue<DataType.CONST_STRING>, unknown> {
+    return { type: DataType.CONST_STRING, value: get_accidental_func(note.value as NoteWithOctave) };
+  }
+
+  @moduleMethod([DataType.CONST_STRING, DataType.NUMBER], DataType.CONST_STRING)
+  async* key_signature_to_key(
+    accidental: TypedValue<DataType.CONST_STRING>,
+    numAccidentals: TypedValue<DataType.NUMBER>
+  ): AsyncGenerator<void, TypedValue<DataType.CONST_STRING>, unknown> {
+    return {
+      type: DataType.CONST_STRING,
+      value: key_signature_to_key_func(accidental.value as Accidental.FLAT | Accidental.SHARP, numAccidentals.value)
+    };
   }
 
   @moduleMethod([DataType.NUMBER], DataType.LIST)

--- a/src/bundles/midi/src/index.ts
+++ b/src/bundles/midi/src/index.ts
@@ -89,7 +89,7 @@ export default class MidiModulePlugin extends BaseModulePlugin {
     note: TypedValue<DataType.NUMBER>,
     accidental: TypedValue<DataType.CONST_STRING>
   ): AsyncGenerator<void, TypedValue<DataType.CONST_STRING>, unknown> {
-    assertAccidental(accidental.value, midi_note_to_letter_name_func.name);
+    assertAccidental(accidental.value, 'midi_note_to_letter_name');
     return { type: DataType.CONST_STRING, value: midi_note_to_letter_name_func(note.value as MIDINote, accidental.value) };
   }
 

--- a/src/bundles/midi/src/utils.ts
+++ b/src/bundles/midi/src/utils.ts
@@ -1,23 +1,23 @@
+import { EvaluatorRuntimeError } from '@sourceacademy/conductor/common';
 import { Accidental, type MIDINote, type Note, type NoteName, type NoteWithOctave } from './types';
 
-export function noteToValues(note: NoteWithOctave, func_name: string = noteToValues.name) {
+export function parseNoteWithOctave(note: NoteWithOctave): [NoteName, Accidental, number];
+export function parseNoteWithOctave(note: unknown): [NoteName, Accidental, number] | null;
+export function parseNoteWithOctave(note: unknown): [NoteName, Accidental, number] | null {
+  if (typeof note !== 'string') return null;
+
   const match = /^([A-Ga-g])([#♮b]?)(\d*)$/.exec(note);
-  if (match === null) throw new Error(`${func_name}: Invalid Note with Octave: ${note}`);
+  if (match === null) return null;
 
   const [, noteName, accidental, octaveStr] = match;
 
   switch (accidental) {
     case Accidental.SHARP: {
-      if (noteName === 'B' || noteName === 'E') {
-        throw new Error(`${func_name}: Invalid Note with Octave: ${note}`);
-      }
-
+      if (noteName === 'B' || noteName === 'E') return null;
       break;
     }
     case Accidental.FLAT: {
-      if (noteName === 'F' || noteName === 'C') {
-        throw new Error(`${func_name}: Invalid Note with Octave: ${note}`);
-      }
+      if (noteName === 'F' || noteName === 'C') return null;
       break;
     }
   }
@@ -30,33 +30,45 @@ export function noteToValues(note: NoteWithOctave, func_name: string = noteToVal
   ] as [NoteName, Accidental, number];
 }
 
-export function midiNoteToNoteName(midiNote: MIDINote, accidental: 'flat' | 'sharp', func_name: string): Note {
+export function noteToValues(note: NoteWithOctave, func_name: string): [NoteName, Accidental, number] {
+  const res = parseNoteWithOctave(note);
+  if (res === null) {
+    throw new EvaluatorRuntimeError(`${func_name}: Invalid Note with Octave: ${note}`);
+  }
+  return res;
+}
+
+export function midiNoteToNoteName(
+  midiNote: MIDINote,
+  accidental: Accidental.FLAT | Accidental.SHARP,
+  func_name: string
+): Note {
   switch (midiNote % 12) {
     case 0:
       return 'C';
     case 1:
-      return accidental === 'sharp' ? `C${Accidental.SHARP}` : `D${Accidental.FLAT}`;
+      return accidental === Accidental.SHARP ? `C${Accidental.SHARP}` : `D${Accidental.FLAT}`;
     case 2:
       return 'D';
     case 3:
-      return accidental === 'sharp' ? `D${Accidental.SHARP}` : `E${Accidental.FLAT}`;
+      return accidental === Accidental.SHARP ? `D${Accidental.SHARP}` : `E${Accidental.FLAT}`;
     case 4:
       return 'E';
     case 5:
       return 'F';
     case 6:
-      return accidental === 'sharp' ? `F${Accidental.SHARP}` : `G${Accidental.FLAT}`;
+      return accidental === Accidental.SHARP ? `F${Accidental.SHARP}` : `G${Accidental.FLAT}`;
     case 7:
       return 'G';
     case 8:
-      return accidental === 'sharp' ? `G${Accidental.SHARP}` : `A${Accidental.FLAT}`;
+      return accidental === Accidental.SHARP ? `G${Accidental.SHARP}` : `A${Accidental.FLAT}`;
     case 9:
       return 'A';
     case 10:
-      return accidental === 'sharp' ? `A${Accidental.SHARP}` : `B${Accidental.FLAT}`;
+      return accidental === Accidental.SHARP ? `A${Accidental.SHARP}` : `B${Accidental.FLAT}`;
     case 11:
       return 'B';
     default:
-      throw new Error(`${func_name}: Invalid MIDI note value ${midiNote}`);
+      throw new EvaluatorRuntimeError(`${func_name}: Invalid MIDI note value ${midiNote}`);
   }
 }

--- a/src/bundles/midi/tsconfig.json
+++ b/src/bundles/midi/tsconfig.json
@@ -5,7 +5,9 @@
   ],
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "experimentalDecorators": false,
+    "emitDecoratorMetadata": false
   },
   "typedocOptions": {
     "name": "midi"

--- a/src/bundles/sound/src/functions.ts
+++ b/src/bundles/sound/src/functions.ts
@@ -1,4 +1,4 @@
-import { midi_note_to_frequency } from '@sourceacademy/bundle-midi';
+import { midi_note_to_frequency } from '@sourceacademy/bundle-midi/functions';
 import {
   accumulate,
   head,

--- a/src/bundles/sound/src/index.ts
+++ b/src/bundles/sound/src/index.ts
@@ -56,6 +56,6 @@ export {
   letter_name_to_midi_note,
   letter_name_to_frequency,
   midi_note_to_frequency
-} from '@sourceacademy/bundle-midi';
+} from '@sourceacademy/bundle-midi/functions';
 
 export { play_in_tab } from './play_in_tab';

--- a/src/bundles/stereo_sound/src/functions.ts
+++ b/src/bundles/stereo_sound/src/functions.ts
@@ -1,4 +1,4 @@
-import { midi_note_to_frequency } from '@sourceacademy/bundle-midi';
+import { midi_note_to_frequency } from '@sourceacademy/bundle-midi/functions';
 import context from 'js-slang/context';
 import {
   accumulate,

--- a/src/bundles/stereo_sound/src/index.ts
+++ b/src/bundles/stereo_sound/src/index.ts
@@ -60,4 +60,4 @@ export {
   letter_name_to_midi_note,
   midi_note_to_frequency,
   letter_name_to_frequency,
-} from '@sourceacademy/bundle-midi';
+} from '@sourceacademy/bundle-midi/functions';


### PR DESCRIPTION
## Description

Fixes #775

Migrates the `midi` module to be Conductor-ready.

`midi` is a dependency of both `sound` and `stereo_sound`, which import several of its functions (`midi_note_to_frequency`, `letter_name_to_midi_note`, `letter_name_to_frequency`) directly as plain TypeScript, and re-export them as part of their own Source-facing APIs. Rewriting `midi`'s functions to require an `IDataHandler` (the way `binary_tree`/`repeat` do) would have broken both of those call sites and re-exports immediately, so this migration keeps a pure, evaluator-free implementation available for cross-bundle TS consumption:

- `functions.ts` / `scales.ts` / `utils.ts` / `types.ts` — pure logic. `scales.ts` still builds js-slang-style lists via `pair`/`List`, same as before.
- `conductorAdapters.ts` — new, undecorated helper used only by the plugin: converts a js-slang scale list into a real Conductor list. Kept out of `index.ts` deliberately — a test file that imports `index.ts` directly hits a decorator syntax error under vitest's transform (it doesn't apply the same decorator settings `tsc` does), so anything meant to be unit-tested needs to live somewhere undecorated.
- `index.ts` — now a `BaseModulePlugin` subclass wrapping the pure functions. `SHARP`/`FLAT`/`NATURAL` are plain string constants, not functions, so `BaseModulePlugin.initialise()` (which only registers `exportedNames` that are functions) can't pick them up — they're pushed onto `this.exports` directly in the constructor instead.
- `sound`/`stereo_sound`: only their imports of `@sourceacademy/bundle-midi` changed, to `@sourceacademy/bundle-midi/functions` (the bundle root now exports the Conductor plugin instead of plain functions). No other changes to either bundle — their own Conductor migration is a separate, larger effort (they're ~90% duplicated implementations of each other; deferred pending a decision on whether to merge them).

Includes the same `__bindExportedMethods()` workaround `repeat`/`rune`/`binary_tree` use for the unbound-method issue in `BaseModulePlugin.initialise()` (source-academy/conductor#41, merged).

### `conductor-migration` had drifted from `master` for this bundle

While this migration was in flight, `master`'s `midi` picked up 6 new functions (`is_note_with_octave`, `add_octave_to_note`, `get_octave`, `get_note_name`, `get_accidental`, `key_signature_to_key`) and input validation on the existing ones (`midi_note_to_frequency` now range-checks its input), none of which existed on `conductor-migration`. This PR ports all of it, using the new `EvaluatorParameterTypeError`/`EvaluatorNumberRangeError`/`assertNumberWithinRange` from **source-academy/conductor#42** (a generic, reusable standardized-error-message addition to Conductor itself, not something bundle-specific) in place of `modules-lib`'s `InvalidParameterTypeError`/`assertNumberWithinRange`, which `functions.ts` can't depend on without pulling js-slang's `modules-lib` re-exports into `sound`/`stereo_sound`'s dependency graph transitively. Message format is unchanged — verified identical to `master`'s existing test expectations.

Also fixes `midi_note_to_letter_name`/`key_signature_to_key`'s `accidental` parameter to match `master`: it's the `Accidental` enum value (`'#'`/`'b'`), not the word `'flat'`/`'sharp'` my first pass used before finding the drift. `midi_note_to_letter_name` silently treats anything other than exactly `SHARP` as flat (matching `master`'s actual, slightly loose behavior) rather than validating it — `key_signature_to_key` is the one that validates, since its own switch has an explicit default case for that.

**Depends on source-academy/conductor#42** (not yet merged) for `EvaluatorParameterTypeError`/`EvaluatorNumberRangeError`/`assertNumberWithinRange`.

## Testing

- `yarn workspace @sourceacademy/bundle-midi run tsc` / `lint` / `test` (29/29) / `build` — all pass
- `yarn workspace @sourceacademy/bundle-sound run tsc` / `test` (28/28) — pass with the updated import path
- `yarn workspace @sourceacademy/bundle-stereo_sound run tsc` / `test` (18/18) — pass with the updated import path
- Verified against the published docs page (source-academy.github.io/modules/documentation/modules/midi.html): every documented function and constant (19 functions + 3 constants, no more, no less) confirmed working end-to-end through the actual compiled bundle, driving each export exactly the way a real evaluator calls a closure (detached, not bound to any instance) rather than just unit-testing the pure logic directly